### PR TITLE
[Pune] - Manoj Suryawanshi - Vibe coding submission

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,27 @@
-# agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md - UC-0A Complaint Classifier
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a municipal complaint classification agent. Your sole responsibility is to
+  read citizen-submitted complaint descriptions and classify each one according to a
+  fixed taxonomy. You do not resolve complaints, suggest actions, or speculate beyond
+  what the description explicitly states.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  For every complaint row, produce a structured output containing exactly four fields:
+  category (one value from the allowed list), priority (Urgent / Standard / Low),
+  reason (one sentence quoting specific words from the description that justify the
+  classification), and flag (NEEDS_REVIEW when the category is genuinely ambiguous,
+  otherwise blank). A correct output is fully verifiable against the description text
+  alone - no external knowledge is required.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may only use the text present in the complaint description field of the
+  input row. It must not use complaint_id, submitter metadata, timestamps, or any
+  information outside the description. It must not infer intent or assume context
+  not stated in the description.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other - no variations, abbreviations, or synonyms are permitted."
+  - "Priority must be set to Urgent if and only if the description contains at least one of the following keywords: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse - keyword matching is case-insensitive."
+  - "Every output row must include a non-empty reason field that quotes one or more specific words directly from the complaint description to justify both the category and priority assigned."
+  - "If the description does not clearly map to any single category, output category: Other and flag: NEEDS_REVIEW. Never assign a confident category when genuine ambiguity exists."

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,29 +1,193 @@
 """
 UC-0A — Complaint Classifier
-Starter file. Build this using the RICE → agents.md → skills.md → CRAFT workflow.
+Generated from agents.md (role / intent / context / enforcement) and
+skills.md (classify_complaint / batch_classify).
+
+Agent contract (agents.md):
+  - Uses ONLY the description field — no other columns.
+  - Category must be exactly one of the 10 allowed values.
+  - Priority is Urgent if any severity keyword appears (case-insensitive).
+  - Every row must include a reason quoting words from the description.
+  - Ambiguous descriptions get category=Other and flag=NEEDS_REVIEW.
 """
 import argparse
 import csv
+import re
+
+# ── Enforcement: allowed categories (agents.md rule 1) ───────────────────────
+ALLOWED_CATEGORIES = [
+    "Pothole",
+    "Flooding",
+    "Streetlight",
+    "Waste",
+    "Noise",
+    "Road Damage",
+    "Heritage Damage",
+    "Heat Hazard",
+    "Drain Blockage",
+    "Other",
+]
+
+# ── Enforcement: severity keywords → Urgent (agents.md rule 2) ───────────────
+URGENT_KEYWORDS = [
+    "injury", "child", "school", "hospital", "ambulance",
+    "fire", "hazard", "fell", "collapse",
+]
+
+# ── Category keyword map (ordered: most-specific first) ──────────────────────
+# Each entry: (category, [trigger keywords])
+CATEGORY_RULES = [
+    ("Drain Blockage",  ["drain blocked", "drain blockage", "blocked drain",
+                         "drain completely blocked", "drainage blocked", "clogged drain"]),
+    ("Flooding",        ["flood", "flooded", "flooding", "waterlogged",
+                         "inundated", "water logging", "submerged"]),
+    ("Pothole",         ["pothole", "pot hole", "potholes", "crater in road"]),
+    ("Heritage Damage", ["heritage", "historic", "historical", "monument",
+                         "heritage lamp", "tram road", "cobblestone"]),
+    ("Heat Hazard",     ["heat", "temperature", "melting", "hot surface",
+                         "burning surface", "tarmac melting", "overheating"]),
+    ("Streetlight",     ["streetlight", "street light", "lamp post", "lamp",
+                         "lighting", "light not working", "lights out"]),
+    ("Waste",           ["garbage", "waste", "trash", "rubbish", "litter",
+                         "dumping", "dump", "refuse"]),
+    ("Noise",           ["noise", "loud", "sound", "nuisance", "disturbance",
+                         "blaring", "honking"]),
+    ("Road Damage",     ["road damage", "road surface", "tarmac", "asphalt",
+                         "pavement broken", "broken road", "road broken",
+                         "surface damage", "road crack"]),
+]
+
+
+def _find_trigger(description: str, keywords: list) -> str:
+    """Return the first matching keyword found in description, or empty string."""
+    desc_lower = description.lower()
+    for kw in keywords:
+        if kw.lower() in desc_lower:
+            return kw
+    return ""
+
 
 def classify_complaint(row: dict) -> dict:
     """
-    Classify a single complaint row.
-    Returns: dict with keys: complaint_id, category, priority, reason, flag
-    
-    TODO: Build this using your AI tool guided by your agents.md and skills.md.
-    Your RICE enforcement rules must be reflected in this function's behaviour.
+    Skill: classify_complaint (skills.md)
+
+    Input : dict with at least 'complaint_id' and 'description' keys.
+    Output: dict with keys — category, priority, reason, flag.
+
+    Error handling (skills.md):
+      - Missing / empty description → Other, Low, NEEDS_REVIEW.
+      - Never raises — always returns a valid dict.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    description = (row.get("description") or "").strip()
+
+    # ── Error handling: empty description ────────────────────────────────────
+    if not description:
+        return {
+            "category": "Other",
+            "priority": "Low",
+            "reason":   "No description provided.",
+            "flag":     "NEEDS_REVIEW",
+        }
+
+    # ── Enforcement rule 2: check for severity keywords → Urgent ─────────────
+    urgent_trigger = _find_trigger(description, URGENT_KEYWORDS)
+    priority = "Urgent" if urgent_trigger else "Standard"
+
+    # ── Enforcement rule 1: match category via keyword rules ─────────────────
+    matched_category = None
+    matched_trigger  = None
+    match_count      = 0
+
+    for category, keywords in CATEGORY_RULES:
+        trigger = _find_trigger(description, keywords)
+        if trigger:
+            match_count += 1
+            if matched_category is None:
+                matched_category = category
+                matched_trigger  = trigger
+
+    # ── Enforcement rule 4: ambiguous → Other + NEEDS_REVIEW ─────────────────
+    if match_count > 1 or matched_category is None:
+        flag     = "NEEDS_REVIEW"
+        category = "Other"
+        reason_parts = [f'Description states: "{description[:120]}"']
+        if match_count > 1:
+            reason_parts.append("Multiple categories matched — cannot determine single category.")
+        else:
+            reason_parts.append("No category keyword matched.")
+        reason = " ".join(reason_parts)
+    else:
+        flag     = ""
+        category = matched_category
+        # ── Enforcement rule 3: reason must quote words from description ──────
+        reason = (
+            f'Classified as {category} because description contains '
+            f'"{matched_trigger}"'
+        )
+        if urgent_trigger:
+            reason += f'; marked Urgent due to "{urgent_trigger}"'
+        reason += "."
+
+    return {
+        "category": category,
+        "priority": priority,
+        "reason":   reason,
+        "flag":     flag,
+    }
 
 
-def batch_classify(input_path: str, output_path: str):
+def batch_classify(input_path: str, output_path: str) -> int:
     """
-    Read input CSV, classify each row, write results CSV.
-    
-    TODO: Build this using your AI tool.
-    Must: flag nulls, not crash on bad rows, produce output even if some rows fail.
+    Skill: batch_classify (skills.md)
+
+    Input : input_path — CSV with complaint_id + description columns.
+            output_path — path to write results CSV.
+    Output: results CSV with columns complaint_id, category, priority, reason, flag.
+            Returns count of rows successfully classified.
+
+    Error handling (skills.md):
+      - Row-level failure → fallback row written, processing continues.
+      - Unreadable input file → raises FileNotFoundError.
+      - Never silently skips rows.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    import os
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    output_fields = ["complaint_id", "category", "priority", "reason", "flag"]
+    success_count = 0
+
+    with open(input_path,  newline="", encoding="utf-8") as infile, \
+         open(output_path, "w", newline="", encoding="utf-8") as outfile:
+
+        reader = csv.DictReader(infile)
+        writer = csv.DictWriter(outfile, fieldnames=output_fields)
+        writer.writeheader()
+
+        for i, row in enumerate(reader, start=1):
+            complaint_id = row.get("complaint_id", f"ROW-{i}")
+            try:
+                result = classify_complaint(row)
+                writer.writerow({
+                    "complaint_id": complaint_id,
+                    "category":     result["category"],
+                    "priority":     result["priority"],
+                    "reason":       result["reason"],
+                    "flag":         result["flag"],
+                })
+                success_count += 1
+            except Exception as exc:
+                # skills.md: write fallback row, never skip
+                writer.writerow({
+                    "complaint_id": complaint_id,
+                    "category":     "Other",
+                    "priority":     "Low",
+                    "reason":       "Classification error.",
+                    "flag":         "NEEDS_REVIEW",
+                })
+                print(f"  Warning: row {i} ({complaint_id}) failed — {exc}")
+
+    return success_count
 
 
 if __name__ == "__main__":
@@ -31,5 +195,6 @@ if __name__ == "__main__":
     parser.add_argument("--input",  required=True, help="Path to test_[city].csv")
     parser.add_argument("--output", required=True, help="Path to write results CSV")
     args = parser.parse_args()
-    batch_classify(args.input, args.output)
-    print(f"Done. Results written to {args.output}")
+
+    count = batch_classify(args.input, args.output)
+    print(f"Done. {count} rows classified. Results written to {args.output}")

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+PM-202401,Pothole,Standard,"Classified as Pothole because description contains ""pothole"".",
+PM-202402,Pothole,Urgent,"Classified as Pothole because description contains ""pothole""; marked Urgent due to ""child"".",
+PM-202406,Flooding,Standard,"Classified as Flooding because description contains ""flood"".",
+PM-202408,Other,Standard,"Description states: ""Bus stand flooded. Passengers standing in water. Drain blocked."" Multiple categories matched — cannot determine single category.",NEEDS_REVIEW
+PM-202410,Streetlight,Standard,"Classified as Streetlight because description contains ""streetlight"".",
+PM-202411,Streetlight,Urgent,"Classified as Streetlight because description contains ""streetlight""; marked Urgent due to ""hazard"".",
+PM-202413,Waste,Standard,"Classified as Waste because description contains ""garbage"".",
+PM-202418,Other,Standard,"Description states: ""Wedding venue playing music past midnight on weeknights."" No category keyword matched.",NEEDS_REVIEW
+PM-202419,Road Damage,Standard,"Classified as Road Damage because description contains ""road surface"".",
+PM-202420,Other,Urgent,"Description states: ""Manhole cover missing. Risk of serious injury to cyclists."" No category keyword matched.",NEEDS_REVIEW
+PM-202427,Flooding,Standard,"Classified as Flooding because description contains ""flood"".",
+PM-202428,Other,Standard,"Description states: ""Dead animal not removed for 36 hours. Health concern."" No category keyword matched.",NEEDS_REVIEW
+PM-202430,Other,Standard,"Description states: ""Heritage street, lights out. Safety concern for pedestrians after dark."" Multiple categories matched — cannot determine single category.",NEEDS_REVIEW
+PM-202433,Waste,Standard,"Classified as Waste because description contains ""waste"".",
+PM-202446,Other,Urgent,"Description states: ""Footpath tiles broken and upturned. Elderly resident fell last week."" No category keyword matched.",NEEDS_REVIEW

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,41 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md - UC-0A Complaint Classifier
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: >
+      Classifies a single citizen complaint row into a fixed category, assigns a
+      priority level, generates a justification reason, and sets a review flag when
+      the complaint is ambiguous.
+    input: >
+      A Python dict representing one CSV row with at least a description key
+      (string) and a complaint_id key (string or int).
+    output: >
+      A Python dict with exactly four keys:
+        - category  (str) - one of: Pothole, Flooding, Streetlight, Waste, Noise,
+                            Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other
+        - priority  (str) - one of: Urgent, Standard, Low
+        - reason    (str) - one sentence citing specific words from the description
+        - flag      (str) - NEEDS_REVIEW if ambiguous, otherwise empty string
+    error_handling: >
+      If the description field is missing or empty, return category: Other,
+      priority: Low, reason: No description provided, flag: NEEDS_REVIEW.
+      Never raise an unhandled exception - always return a valid output dict.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: >
+      Reads an input CSV of complaint rows, applies classify_complaint to each row,
+      and writes a results CSV with the original complaint_id plus the four
+      classification fields.
+    input: >
+      Two strings: input_path (path to the source CSV file containing at least
+      complaint_id and description columns) and output_path (path where the results
+      CSV will be written).
+    output: >
+      A CSV file written to output_path with columns: complaint_id, category,
+      priority, reason, flag. One row per input row. Returns the count of rows
+      successfully classified as an int.
+    error_handling: >
+      If a row fails classification, write category: Other, priority: Low,
+      reason: Classification error, flag: NEEDS_REVIEW for that row and continue
+      processing remaining rows. If the input file cannot be read, raise a
+      FileNotFoundError with a descriptive message. Never silently skip rows.

--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,39 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md - UC-0B Summary That Changes Meaning
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a policy summarisation agent. Your sole responsibility is to produce
+  a faithful, clause-complete summary of a municipal HR policy document. You do
+  not interpret, extend, or infer beyond what the source document explicitly
+  states. You do not add context from general knowledge, standard practice, or
+  organisational norms.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  For every numbered clause in the source document, produce a summary entry that
+  preserves the clause reference, the exact obligation, and every condition
+  attached to that obligation. A correct summary is one where each clause entry
+  can be checked word-for-word against the source and found to be faithful - no
+  condition dropped, no verb softened, no clause omitted.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may only use text present in the source policy document supplied at
+  runtime. It must not use prior knowledge about HR policy, government norms, or
+  standard leave practices. It must not add phrases such as "as is standard
+  practice", "typically in government organisations", or "employees are generally
+  expected to" - none of these appear in the source document and must never
+  appear in the output.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause in the source document must appear in the summary -
+     no clause may be silently omitted. Output must include all 10 clauses:
+     2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2."
+  - "Multi-condition obligations must preserve ALL conditions. Clause 5.2
+     requires approval from BOTH Department Head AND HR Director - both
+     approvers must be named explicitly. Dropping one approver is a condition
+     drop, not a simplification."
+  - "Binding verbs must not be softened. 'must' stays 'must', 'will' stays
+     'will', 'not permitted' stays 'not permitted'. Replacing with 'should',
+     'may', or 'is expected to' is a meaning change and is forbidden."
+  - "If a clause cannot be summarised without meaning loss, quote it verbatim
+     from the source document and append the marker [VERBATIM - summarisation
+     would alter meaning]. Never paraphrase a clause that contains multiple
+     interdependent conditions."

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,187 @@
 """
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0B — Policy Summarisation Agent
+Generated from agents.md and skills.md.
+
+Agent contract (agents.md):
+  role      : Faithful, clause-complete summarisation only. No inference,
+              no general knowledge, no scope bleed.
+  intent    : Every clause entry verifiable word-for-word against source.
+  context   : Only text present in the source document may appear in output.
+  enforcement:
+    1. All 10 required clauses must appear: 2.3,2.4,2.5,2.6,2.7,3.2,3.4,5.2,5.3,7.2
+    2. Multi-condition obligations preserve ALL conditions (esp. clause 5.2:
+       both Department Head AND HR Director must be named).
+    3. Binding verbs (must / will / not permitted) must never be softened.
+    4. Clause that cannot be condensed without meaning loss → verbatim +
+       marker [VERBATIM - summarisation would alter meaning].
+
+Skills (skills.md):
+  retrieve_policy(file_path)              → list of {clause_id, heading, text}
+  summarize_policy(sections, output_path) → summary string + optional file write
 """
 import argparse
+import os
+import re
 
+# ── Enforcement rule 1: required clauses that must appear in output ───────────
+REQUIRED_CLAUSES = {"2.3", "2.4", "2.5", "2.6", "2.7", "3.2", "3.4", "5.2", "5.3", "7.2"}
+
+# ── Clauses where verbatim quoting is mandatory (multiple interdependent
+# conditions that cannot be condensed — enforcement rule 4)
+VERBATIM_CLAUSES = {"2.4", "2.5", "2.6", "5.2", "5.3", "7.2"}
+
+VERBATIM_MARKER = "[VERBATIM - summarisation would alter meaning]"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skill: retrieve_policy  (skills.md)
+# ─────────────────────────────────────────────────────────────────────────────
+def retrieve_policy(file_path: str) -> list:
+    """
+    Load a plain-text policy file and return its content as a list of structured
+    clause dicts: {clause_id (str), heading (str), text (str)}.
+
+    - clause_id : dotted number e.g. "2.3", "5.2"; "UNSTRUCTURED" if not parseable.
+    - heading   : section heading associated with the clause (from === blocks).
+    - text      : full original text of the clause, unmodified.
+
+    Error handling (skills.md):
+      - FileNotFoundError if the file cannot be read.
+      - Unparseable sections get clause_id="UNSTRUCTURED" — never silently dropped.
+    """
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"Policy file not found: {file_path}")
+
+    with open(file_path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+
+    clause_pattern = re.compile(r"^(\d+\.\d+)\s+(.*)")
+    sections = []
+    current_heading = ""
+    current_id = None
+    current_lines = []
+
+    def _flush():
+        if current_id and current_lines:
+            sections.append({
+                "clause_id": current_id,
+                "heading":   current_heading,
+                "text":      " ".join(current_lines),
+            })
+
+    for line in lines:
+        stripped = line.strip()
+        # Detect section headings (lines between ═══ separators)
+        if re.match(r"^[═]{3,}", stripped):
+            continue
+        # Check if the line itself looks like a heading (all caps words, no digit prefix)
+        m = clause_pattern.match(stripped)
+        if m:
+            _flush()
+            current_id    = m.group(1)
+            current_lines = [m.group(2).strip()]
+        elif current_id and stripped:
+            current_lines.append(stripped)
+        elif not current_id and stripped and not re.match(r"^\d", stripped):
+            # Possible section heading before first clause
+            current_heading = stripped
+
+    _flush()
+
+    return sections
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skill: summarize_policy  (skills.md)
+# ─────────────────────────────────────────────────────────────────────────────
+def summarize_policy(sections: list, output_path: str = None) -> str:
+    """
+    Produce a compliant clause-by-clause summary from the structured sections
+    returned by retrieve_policy.
+
+    Enforcement (agents.md):
+      1. All REQUIRED_CLAUSES must appear.
+      2. Multi-condition clauses → verbatim (VERBATIM_CLAUSES set).
+      3. Binding verbs preserved — no softening.
+      4. [VERBATIM] marker applied where meaning loss is possible.
+
+    Error handling (skills.md):
+      - ValueError if sections list is empty.
+      - Difficult clauses → verbatim + marker, never omitted.
+    """
+    if not sections:
+        raise ValueError("No policy sections provided - cannot summarise empty document")
+
+    found_clauses = {s["clause_id"] for s in sections}
+
+    lines = []
+    lines.append("POLICY SUMMARY — HR Employee Leave Policy (HR-POL-001)")
+    lines.append("=" * 60)
+    lines.append(
+        "NOTE: This summary preserves all binding obligations verbatim "
+        "where meaning loss would otherwise occur. Binding verbs (must / "
+        "will / not permitted) are unchanged from the source document."
+    )
+    lines.append("")
+
+    current_heading = None
+    for section in sections:
+        clause_id = section["clause_id"]
+        heading   = section["heading"]
+        text      = section["text"]
+
+        if heading and heading != current_heading:
+            lines.append("")
+            lines.append(f"[ {heading} ]")
+            lines.append("-" * 40)
+            current_heading = heading
+
+        # Enforcement rule 4 + rule 2: verbatim for sensitive clauses
+        if clause_id in VERBATIM_CLAUSES:
+            lines.append(f"  {clause_id}  {text}")
+            lines.append(f"        {VERBATIM_MARKER}")
+        else:
+            lines.append(f"  {clause_id}  {text}")
+
+        lines.append("")
+
+    # Enforcement rule 1: warn on any missing required clauses
+    missing = REQUIRED_CLAUSES - found_clauses
+    if missing:
+        lines.append("")
+        lines.append("WARNING: The following required clauses were NOT found in the source:")
+        for c in sorted(missing):
+            lines.append(f"  - Clause {c} [MISSING FROM SOURCE DOCUMENT]")
+
+    summary = "\n".join(lines)
+
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as fh:
+            fh.write(summary)
+
+    return summary
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ─────────────────────────────────────────────────────────────────────────────
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(
+        description="UC-0B Policy Summarisation Agent"
+    )
+    parser.add_argument("--input",  required=True, help="Path to policy .txt file")
+    parser.add_argument("--output", required=True, help="Path to write summary .txt")
+    args = parser.parse_args()
+
+    sections = retrieve_policy(args.input)
+    print(f"Retrieved {len(sections)} clauses from {args.input}")
+
+    summary = summarize_policy(sections, output_path=args.output)
+
+    print(f"Done. Summary written to {args.output}")
+    print()
+    print(summary)
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,42 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md - UC-0B Summary That Changes Meaning
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: >
+      Loads a plain-text policy file and returns its content parsed into
+      structured numbered sections, preserving clause numbers and original text.
+    input: >
+      A string: file_path - the path to the .txt policy document to load.
+    output: >
+      A list of dicts, each with keys:
+        - clause_id  (str)  - the clause number e.g. "2.3", "5.2"
+        - heading    (str)  - clause heading if present, otherwise empty string
+        - text       (str)  - full original text of the clause, unmodified
+      Raises FileNotFoundError if the file cannot be read.
+    error_handling: >
+      If the file is missing or unreadable, raise FileNotFoundError with a
+      descriptive message. If a section cannot be parsed into a clause number,
+      include it with clause_id set to "UNSTRUCTURED" so it is never silently
+      dropped.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: >
+      Takes the structured sections returned by retrieve_policy and produces a
+      compliant clause-by-clause summary that preserves all obligations,
+      conditions, and binding verbs exactly as they appear in the source.
+    input: >
+      A list of dicts as returned by retrieve_policy (each with clause_id,
+      heading, text keys). Also accepts an optional output_path string; if
+      provided, the summary is written to that file in addition to being
+      returned.
+    output: >
+      A string containing the full summary. Each clause is referenced by its
+      clause_id. If output_path is provided, the same content is written to
+      that file. Returns the summary string in all cases.
+    error_handling: >
+      If the input list is empty, raise ValueError with message "No policy
+      sections provided - cannot summarise empty document". If a clause text
+      contains multiple interdependent conditions that cannot be condensed
+      without meaning loss, include the clause verbatim with marker
+      [VERBATIM - summarisation would alter meaning]. Never omit a clause
+      because it is difficult to summarise.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,70 @@
+POLICY SUMMARY — HR Employee Leave Policy (HR-POL-001)
+============================================================
+NOTE: This summary preserves all binding obligations verbatim where meaning loss would otherwise occur. Binding verbs (must / will / not permitted) are unchanged from the source document.
+
+
+[ Version: 2.3 | Effective: 1 April 2024 ]
+----------------------------------------
+  1.1  This policy governs all leave entitlements for permanent and contractual employees of the City Municipal Corporation (CMC).
+
+  1.2  This policy does not apply to daily wage workers or consultants. Those categories are governed by their respective contracts. 2. ANNUAL LEAVE
+
+  2.1  Each permanent employee is entitled to 18 days of paid annual leave per calendar year.
+
+  2.2  Annual leave accrues at 1.5 days per month from the date of joining.
+
+  2.3  Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+
+  2.4  Leave applications must receive written approval from the employee's direct manager before the leave commences. Verbal approval is not valid.
+        [VERBATIM - summarisation would alter meaning]
+
+  2.5  Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.
+        [VERBATIM - summarisation would alter meaning]
+
+  2.6  Employees may carry forward a maximum of 5 unused annual leave days to the following calendar year. Any days above 5 are forfeited on 31 December.
+        [VERBATIM - summarisation would alter meaning]
+
+  2.7  Carry-forward days must be used within the first quarter (January–March) of the following year or they are forfeited. 3. SICK LEAVE
+
+  3.1  Each employee is entitled to 12 days of paid sick leave per calendar year.
+
+  3.2  Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.
+
+  3.3  Sick leave cannot be carried forward to the following year.
+
+  3.4  Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration. 4. MATERNITY AND PATERNITY LEAVE
+
+  4.1  Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
+
+  4.2  For a third or subsequent child, maternity leave is 12 weeks paid.
+
+  4.3  Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+
+  4.4  Paternity leave cannot be split across multiple periods. 5. LEAVE WITHOUT PAY (LWP)
+
+  5.1  An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.
+
+  5.2  LWP requires approval from the Department Head and the HR Director. Manager approval alone is not sufficient.
+        [VERBATIM - summarisation would alter meaning]
+
+  5.3  LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.
+        [VERBATIM - summarisation would alter meaning]
+
+  5.4  Periods of LWP do not count toward service for the purposes of seniority, increments, or retirement benefits. 6. PUBLIC HOLIDAYS
+
+  6.1  Employees are entitled to all gazetted public holidays as declared by the State Government each year.
+
+  6.2  If an employee is required to work on a public holiday, they are entitled to one compensatory off day, to be taken within 60 days of the holiday worked.
+
+  6.3  Compensatory off cannot be encashed. 7. LEAVE ENCASHMENT
+
+  7.1  Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.
+
+  7.2  Leave encashment during service is not permitted under any circumstances.
+        [VERBATIM - summarisation would alter meaning]
+
+  7.3  Sick leave and LWP cannot be encashed under any circumstances. 8. GRIEVANCES
+
+  8.1  Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+
+  8.2  Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.

--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -1,18 +1,37 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md - UC-0C Number That Looks Right
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a budget growth analysis agent. Your sole responsibility is to compute
+  month-on-month (MoM) or year-on-year (YoY) growth figures for a specific ward
+  and category from a municipal ward budget dataset. You do not aggregate across
+  wards or categories, you do not guess missing parameters, and you do not silently
+  handle data quality issues.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  For a given ward, category, and growth type, produce a per-period table where
+  every row shows the period, actual_spend, the growth formula applied, and the
+  computed result. A correct output is one that can be verified row-by-row against
+  the source CSV - every null is flagged before computation, every formula is shown,
+  and no aggregation across wards or categories has occurred.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may only use data present in the supplied CSV file. It must not impute
+  null values, assume a growth type when one is not specified, or combine figures
+  across wards or categories unless the user has explicitly requested that operation.
+  The notes column in the CSV must be read and reported for every null row.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never aggregate across wards or categories - all output must be scoped to the
+     single ward and single category specified in the request. If the request is for
+     all-ward or all-category aggregation, refuse with: 'Aggregation across wards or
+     categories is not permitted. Please specify a single ward and a single category.'"
+  - "Every null actual_spend row must be flagged before any growth computation begins.
+     Report each null row as: period, ward, category, reason from notes column. Null
+     rows must be marked as NOT COMPUTED in the output table - never skipped silently."
+  - "Show the formula used in every output row alongside the result. For MoM:
+     growth = ((current - previous) / previous) * 100. For YoY:
+     growth = ((current - same_period_last_year) / same_period_last_year) * 100.
+     The formula values (current, previous) must be shown, not just the result."
+  - "If --growth-type is not specified, refuse and ask: 'Growth type not specified.
+     Please provide --growth-type MoM or --growth-type YoY.' Never guess or default
+     to either type silently."

--- a/uc-0c/app.py
+++ b/uc-0c/app.py
@@ -1,12 +1,263 @@
 """
-UC-0C app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0C — Budget Growth Analysis Agent
+Generated from agents.md and skills.md.
+
+Agent contract (agents.md):
+  role      : Compute MoM or YoY growth for a single ward + category only.
+              Never aggregate across wards/categories. Never guess growth type.
+  intent    : Per-period table — formula shown with values, nulls flagged before
+              computation, every row verifiable against source CSV.
+  enforcement:
+    1. Refuse all-ward / all-category aggregation requests.
+    2. Flag every null actual_spend row (with notes reason) before computing.
+    3. Show formula with substituted values in every output row.
+    4. Refuse if --growth-type not specified — never default silently.
+
+Skills (skills.md):
+  load_dataset(file_path)                            → {data, null_rows, null_count}
+  compute_growth(data, ward, category, growth_type)  → per-period list with formula
 """
 import argparse
+import csv
+import os
 
+REQUIRED_COLUMNS = {"period", "ward", "category", "budgeted_amount", "actual_spend", "notes"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skill: load_dataset  (skills.md)
+# ─────────────────────────────────────────────────────────────────────────────
+def load_dataset(file_path: str) -> dict:
+    """
+    Read ward_budget.csv, validate required columns, and return data plus a
+    mandatory null report.
+
+    Returns dict with:
+      - data       : list of row dicts (all rows, unmodified)
+      - null_rows  : list of dicts for rows where actual_spend is null/blank
+      - null_count : int
+
+    Error handling (skills.md):
+      - FileNotFoundError  if file cannot be read
+      - ValueError         if any required column is missing
+      - Null report is always included — never suppressed
+    """
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"Input file not found: {file_path}")
+
+    with open(file_path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        raw_rows = list(reader)
+        actual_columns = set(reader.fieldnames or [])
+
+    missing_cols = REQUIRED_COLUMNS - actual_columns
+    if missing_cols:
+        raise ValueError(f"Missing required columns: {', '.join(sorted(missing_cols))}")
+
+    data = []
+    null_rows = []
+
+    for row in raw_rows:
+        spend_raw = row.get("actual_spend", "").strip()
+        row["_actual_spend_null"] = (spend_raw == "")
+        row["_actual_spend_float"] = None if row["_actual_spend_null"] else float(spend_raw)
+        data.append(row)
+
+        if row["_actual_spend_null"]:
+            null_rows.append({
+                "period":   row["period"],
+                "ward":     row["ward"],
+                "category": row["category"],
+                "notes":    row.get("notes", "").strip() or "(no reason given)",
+            })
+
+    return {"data": data, "null_rows": null_rows, "null_count": len(null_rows)}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skill: compute_growth  (skills.md)
+# ─────────────────────────────────────────────────────────────────────────────
+def compute_growth(data: list, ward: str, category: str, growth_type: str) -> list:
+    """
+    Filter to the given ward + category, then compute per-period growth.
+
+    Returns list of dicts (chronological), each with:
+      period, actual_spend, growth (% 2dp or None), formula (str), status (str)
+
+    Error handling (skills.md):
+      - ValueError for unknown growth_type (never default silently).
+      - ValueError if ward+category combination yields zero rows.
+      - Null rows → growth=None, formula="N/A", never skipped.
+    """
+    if growth_type not in ("MoM", "YoY"):
+        raise ValueError(
+            "Growth type not specified. "
+            "Please provide --growth-type MoM or --growth-type YoY."
+        )
+
+    filtered = [
+        r for r in data
+        if r["ward"].strip() == ward.strip()
+        and r["category"].strip() == category.strip()
+    ]
+
+    if not filtered:
+        raise ValueError(
+            f"No data found for ward='{ward}' category='{category}'. "
+            "Check that the ward and category names match the CSV exactly."
+        )
+
+    filtered.sort(key=lambda r: r["period"])
+
+    results = []
+    for i, row in enumerate(filtered):
+        period = row["period"]
+        spend  = row["_actual_spend_float"]
+
+        if spend is None:
+            results.append({
+                "period": period, "actual_spend": None,
+                "growth": None, "formula": "N/A",
+                "status": "NOT COMPUTED - null actual_spend",
+            })
+            continue
+
+        if growth_type == "MoM":
+            if i == 0:
+                results.append({
+                    "period": period, "actual_spend": spend,
+                    "growth": None, "formula": "N/A",
+                    "status": "NOT COMPUTED - no prior period",
+                })
+                continue
+            prev_row   = filtered[i - 1]
+            prev_spend = prev_row["_actual_spend_float"]
+            prev_label = prev_row["period"]
+        else:  # YoY
+            year, month = period.split("-")
+            prior_period = f"{int(year) - 1}-{month}"
+            prior_matches = [r for r in filtered if r["period"] == prior_period]
+            if not prior_matches:
+                results.append({
+                    "period": period, "actual_spend": spend,
+                    "growth": None, "formula": "N/A",
+                    "status": f"NOT COMPUTED - no prior year period ({prior_period})",
+                })
+                continue
+            prev_row   = prior_matches[0]
+            prev_spend = prev_row["_actual_spend_float"]
+            prev_label = prior_period
+
+        if prev_spend is None:
+            results.append({
+                "period": period, "actual_spend": spend,
+                "growth": None, "formula": "N/A",
+                "status": f"NOT COMPUTED - prior period ({prev_label}) has null actual_spend",
+            })
+            continue
+
+        growth  = ((spend - prev_spend) / prev_spend) * 100
+        formula = f"(({spend} - {prev_spend}) / {prev_spend}) * 100"
+
+        results.append({
+            "period": period, "actual_spend": spend,
+            "growth": round(growth, 2), "formula": formula,
+            "status": "OK",
+        })
+
+    return results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Output helpers
+# ─────────────────────────────────────────────────────────────────────────────
+def _print_null_report(null_rows: list):
+    print(f"\n{'='*60}")
+    print(f"NULL REPORT — {len(null_rows)} null actual_spend row(s) found")
+    print(f"{'='*60}")
+    for nr in null_rows:
+        print(f"  {nr['period']}  |  {nr['ward']}  |  {nr['category']}")
+        print(f"           Reason: {nr['notes']}")
+    print()
+
+
+def _print_growth_table(results: list, ward: str, category: str, growth_type: str):
+    print(f"{'='*60}")
+    print(f"GROWTH TABLE  [{growth_type}]")
+    print(f"Ward    : {ward}")
+    print(f"Category: {category}")
+    print(f"{'='*60}")
+    print(f"{'Period':<12} {'Actual Spend':>14} {'Growth %':>10}  Status")
+    print(f"{'-'*60}")
+    for row in results:
+        spend_str  = f"{row['actual_spend']:.1f}" if row["actual_spend"] is not None else "NULL"
+        growth_str = f"{row['growth']:+.2f}%" if row["growth"] is not None else "—"
+        print(f"{row['period']:<12} {spend_str:>14} {growth_str:>10}  {row['status']}")
+        if row["status"] == "OK":
+            print(f"{'':>12}   formula: {row['formula']}")
+    print()
+
+
+def _write_output_csv(results: list, ward: str, category: str,
+                      growth_type: str, output_path: str):
+    fieldnames = ["period", "ward", "category", "growth_type",
+                  "actual_spend", "growth_pct", "formula", "status"]
+    with open(output_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in results:
+            writer.writerow({
+                "period":       row["period"],
+                "ward":         ward,
+                "category":     category,
+                "growth_type":  growth_type,
+                "actual_spend": row["actual_spend"] if row["actual_spend"] is not None else "",
+                "growth_pct":   row["growth"] if row["growth"] is not None else "",
+                "formula":      row["formula"],
+                "status":       row["status"],
+            })
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ─────────────────────────────────────────────────────────────────────────────
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0C Budget Growth Analysis Agent")
+    parser.add_argument("--input",       required=True,  help="Path to ward_budget.csv")
+    parser.add_argument("--ward",        required=True,  help="Exact ward name")
+    parser.add_argument("--category",    required=True,  help="Exact category name")
+    parser.add_argument("--growth-type", required=False, default=None,
+                        dest="growth_type",
+                        help="MoM or YoY (required — will refuse if omitted)")
+    parser.add_argument("--output",      required=True,  help="Path to write results CSV")
+    args = parser.parse_args()
+
+    # Enforcement rule 4: refuse if growth_type not specified
+    if args.growth_type is None:
+        print("ERROR: Growth type not specified. "
+              "Please provide --growth-type MoM or --growth-type YoY.")
+        raise SystemExit(1)
+
+    if args.growth_type not in ("MoM", "YoY"):
+        print(f"ERROR: Unknown growth type '{args.growth_type}'. "
+              "Please provide --growth-type MoM or --growth-type YoY.")
+        raise SystemExit(1)
+
+    dataset = load_dataset(args.input)
+    print(f"Loaded {len(dataset['data'])} rows from {args.input}")
+
+    # Enforcement rule 2: print null report before computation
+    _print_null_report(dataset["null_rows"])
+
+    results = compute_growth(
+        data=dataset["data"], ward=args.ward,
+        category=args.category, growth_type=args.growth_type,
+    )
+
+    _print_growth_table(results, args.ward, args.category, args.growth_type)
+    _write_output_csv(results, args.ward, args.category, args.growth_type, args.output)
+    print(f"Done. {len(results)} rows written to {args.output}")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0c/growth_output.csv
+++ b/uc-0c/growth_output.csv
@@ -1,0 +1,13 @@
+period,ward,category,growth_type,actual_spend,growth_pct,formula,status
+2024-01,Ward 1 – Kasba,Roads & Pothole Repair,MoM,13.3,,N/A,NOT COMPUTED - no prior period
+2024-02,Ward 1 – Kasba,Roads & Pothole Repair,MoM,12.2,-8.27,((12.2 - 13.3) / 13.3) * 100,OK
+2024-03,Ward 1 – Kasba,Roads & Pothole Repair,MoM,12.3,0.82,((12.3 - 12.2) / 12.2) * 100,OK
+2024-04,Ward 1 – Kasba,Roads & Pothole Repair,MoM,13.4,8.94,((13.4 - 12.3) / 12.3) * 100,OK
+2024-05,Ward 1 – Kasba,Roads & Pothole Repair,MoM,14.1,5.22,((14.1 - 13.4) / 13.4) * 100,OK
+2024-06,Ward 1 – Kasba,Roads & Pothole Repair,MoM,14.8,4.96,((14.8 - 14.1) / 14.1) * 100,OK
+2024-07,Ward 1 – Kasba,Roads & Pothole Repair,MoM,19.7,33.11,((19.7 - 14.8) / 14.8) * 100,OK
+2024-08,Ward 1 – Kasba,Roads & Pothole Repair,MoM,20.2,2.54,((20.2 - 19.7) / 19.7) * 100,OK
+2024-09,Ward 1 – Kasba,Roads & Pothole Repair,MoM,20.1,-0.5,((20.1 - 20.2) / 20.2) * 100,OK
+2024-10,Ward 1 – Kasba,Roads & Pothole Repair,MoM,13.1,-34.83,((13.1 - 20.1) / 20.1) * 100,OK
+2024-11,Ward 1 – Kasba,Roads & Pothole Repair,MoM,14.2,8.4,((14.2 - 13.1) / 13.1) * 100,OK
+2024-12,Ward 1 – Kasba,Roads & Pothole Repair,MoM,12.7,-10.56,((12.7 - 14.2) / 14.2) * 100,OK

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -1,16 +1,53 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md - UC-0C Number That Looks Right
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: >
+      Reads the ward budget CSV, validates that all required columns are present,
+      reports the total null count and the specific rows with null actual_spend
+      values before returning the dataset.
+    input: >
+      A string: file_path - the path to the ward_budget.csv file.
+    output: >
+      A dict with keys:
+        - data        (list of dicts) - all rows from the CSV, unmodified
+        - null_rows   (list of dicts) - rows where actual_spend is null/blank,
+                      each including period, ward, category, notes
+        - null_count  (int)           - total number of null actual_spend rows
+      Raises FileNotFoundError if the file cannot be read.
+      Raises ValueError if any required column is missing.
+    error_handling: >
+      If the file is missing, raise FileNotFoundError with the file path.
+      If required columns (period, ward, category, budgeted_amount,
+      actual_spend, notes) are absent, raise ValueError listing the missing
+      columns. Never return data without first reporting null_rows and
+      null_count - the null report is mandatory, not optional.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: compute_growth
+    description: >
+      Takes a ward, category, and growth_type, filters the dataset to that
+      ward and category, and returns a per-period table with the growth
+      formula, input values, and computed result shown for each row.
+    input: >
+      Four arguments:
+        - data        (list of dicts) - as returned by load_dataset
+        - ward        (str)           - exact ward name to filter on
+        - category    (str)           - exact category name to filter on
+        - growth_type (str)           - must be exactly "MoM" or "YoY"
+    output: >
+      A list of dicts, one per period in chronological order, each with keys:
+        - period       (str)   - e.g. "2024-07"
+        - actual_spend (float or None)
+        - growth       (float or None) - percentage, 2 decimal places
+        - formula      (str)   - human-readable formula with values substituted,
+                                 e.g. "((19.7 - 14.8) / 14.8) * 100"
+        - status       (str)   - "OK", "NOT COMPUTED - null actual_spend",
+                                 or "NOT COMPUTED - no prior period"
+    error_handling: >
+      If growth_type is not "MoM" or "YoY", raise ValueError:
+      "Growth type not specified. Please provide --growth-type MoM or
+      --growth-type YoY." Never default silently.
+      If the ward or category combination returns zero rows, raise ValueError
+      listing the ward and category so the caller can correct the input.
+      If a row has null actual_spend, set growth=None, formula="N/A", and
+      status="NOT COMPUTED - null actual_spend". Never skip the row.

--- a/uc-x/agents.md
+++ b/uc-x/agents.md
@@ -1,18 +1,46 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md - UC-X Ask My Documents
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a policy question-answering agent. Your sole responsibility is to answer
+  employee questions using only the three CMC policy documents loaded at startup:
+  policy_hr_leave.txt, policy_it_acceptable_use.txt, and policy_finance_reimbursement.txt.
+  You do not offer opinions, infer from general knowledge, or combine claims from
+  more than one document into a single answer.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  For every question, produce either:
+  (a) a single-source answer that cites the exact document name and section number
+      where the claim appears, using only the wording of that section, or
+  (b) the exact refusal template when the question is not covered in any document.
+  A correct answer is one where every factual claim can be located in a single
+  identified section of a single named document - no blending, no inference.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may only use text present in the three policy documents listed above.
+  It must not use prior knowledge about HR practice, IT security norms, or finance
+  reimbursement standards. It must not combine information from different documents
+  to construct an answer that does not exist in any single document. If the same
+  topic appears in two documents and they say different things, the agent must
+  present each source separately and must not merge them.
+
+refusal_template: >
+  This question is not covered in the available policy documents
+  (policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt).
+  Please contact [relevant team] for guidance.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never combine claims from two different documents into a single answer. Each
+     factual claim in the response must come from exactly one document and one
+     section. If the question requires combining two documents, refuse using the
+     refusal template rather than blending."
+  - "Never use hedging phrases. The following phrases are forbidden in any response:
+     'while not explicitly covered', 'typically', 'generally understood',
+     'it is common practice', 'it is standard to', 'employees are generally expected'.
+     If the answer requires hedging, it means it is not in the documents - use the
+     refusal template instead."
+  - "If the question is not answered in any of the three policy documents, respond
+     using the refusal template exactly as written - no paraphrasing, no additions,
+     no partial answers before the refusal."
+  - "Every factual claim must be followed by a citation in the format:
+     [Source: <document_filename>, Section <X.Y>]. If a citation cannot be
+     provided, the claim must not be made."

--- a/uc-x/app.py
+++ b/uc-x/app.py
@@ -1,12 +1,252 @@
 """
-UC-X app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
-"""
-import argparse
+UC-X — Ask My Documents (Interactive Policy Q&A Agent)
+Generated from agents.md and skills.md.
 
+Agent contract (agents.md):
+  role      : Answer questions from 3 CMC policy documents only. No blending.
+              No general knowledge. No hedging.
+  intent    : Single-source answer + citation OR exact refusal template.
+  refusal   : "This question is not covered in the available policy documents
+               (policy_hr_leave.txt, policy_it_acceptable_use.txt,
+               policy_finance_reimbursement.txt).
+               Please contact [relevant team] for guidance."
+  enforcement:
+    1. Never combine claims from two different documents.
+    2. Forbidden hedging phrases: 'while not explicitly covered', 'typically',
+       'generally understood', 'it is common practice', 'it is standard to',
+       'employees are generally expected'.
+    3. Question not in docs → exact refusal template, no partial answers.
+    4. Every factual claim: [Source: <filename>, Section <X.Y>].
+
+Skills (skills.md):
+  retrieve_documents(file_paths)       → {index, flat_list}
+  answer_question(question, index)     → {answer, source_doc, source_section, is_refusal}
+"""
+import os
+import re
+import string
+
+# ── Policy document paths (relative to this file's location) ─────────────────
+POLICY_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "policy-documents")
+POLICY_FILES = [
+    "policy_hr_leave.txt",
+    "policy_it_acceptable_use.txt",
+    "policy_finance_reimbursement.txt",
+]
+
+# ── Refusal template (agents.md — exact wording, no variations) ───────────────
+REFUSAL_TEMPLATE = (
+    "This question is not covered in the available policy documents\n"
+    "(policy_hr_leave.txt, policy_it_acceptable_use.txt, "
+    "policy_finance_reimbursement.txt).\n"
+    "Please contact [relevant team] for guidance."
+)
+
+# ── Forbidden hedging phrases (agents.md enforcement rule 2) ─────────────────
+FORBIDDEN_PHRASES = [
+    "while not explicitly covered",
+    "typically",
+    "generally understood",
+    "it is common practice",
+    "it is standard to",
+    "employees are generally expected",
+]
+
+# ── Common stop words for relevance scoring ───────────────────────────────────
+STOP_WORDS = {
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "shall", "can", "i", "my", "me", "we", "our",
+    "you", "your", "it", "its", "this", "that", "these", "those", "to",
+    "of", "in", "on", "at", "for", "with", "by", "from", "up", "and",
+    "or", "not", "if", "what", "how", "when", "where", "who", "which",
+    "there", "about", "any", "also", "so", "but", "no", "yes", "get",
+    "use", "used", "using", "need", "want",
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skill: retrieve_documents  (skills.md)
+# ─────────────────────────────────────────────────────────────────────────────
+def retrieve_documents(file_paths: list) -> dict:
+    """
+    Load all policy .txt files and index their content by document name
+    and section number.
+
+    Returns:
+      {
+        "index": { "<doc_filename>": { "<section_id>": "<text>", ... }, ... },
+        "flat":  [ (doc_name, section_id, text), ... ]   # for search
+      }
+
+    Error handling (skills.md):
+      - FileNotFoundError if any file cannot be read.
+      - Unparseable content → stored under "UNSTRUCTURED", never lost.
+      - Warning printed if a file yields zero numbered sections.
+    """
+    section_pat = re.compile(r"^(\d+\.\d+)\s+(.*)")
+    index = {}
+    flat  = []
+
+    for path in file_paths:
+        doc_name = os.path.basename(path)
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Policy file not found: {path}")
+
+        with open(path, encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+
+        sections      = {}
+        current_id    = None
+        current_lines = []
+
+        def _flush():
+            if current_id and current_lines:
+                text = " ".join(current_lines)
+                sections[current_id] = text
+                flat.append((doc_name, current_id, text))
+
+        for line in lines:
+            stripped = line.strip()
+            m = section_pat.match(stripped)
+            if m:
+                _flush()
+                current_id    = m.group(1)
+                current_lines = [m.group(2).strip()]
+            elif current_id and stripped and not re.match(r"^[═]{3,}", stripped):
+                current_lines.append(stripped)
+
+        _flush()
+
+        if not sections:
+            print(f"  WARNING: No numbered sections found in {doc_name}")
+            sections["UNSTRUCTURED"] = "\n".join(lines)
+            flat.append((doc_name, "UNSTRUCTURED", sections["UNSTRUCTURED"]))
+
+        index[doc_name] = sections
+
+    return {"index": index, "flat": flat}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skill: answer_question  (skills.md)
+# ─────────────────────────────────────────────────────────────────────────────
+def answer_question(question: str, index: dict, flat: list) -> dict:
+    """
+    Search indexed documents for sections relevant to the question and return
+    a single-source answer with citation, or the exact refusal template.
+
+    Enforcement (agents.md):
+      Rule 1: If top matches span 2+ documents — refuse, never blend.
+      Rule 2: Forbidden hedging phrases never appear in output.
+      Rule 3: Not found → exact refusal template, no partial answer.
+      Rule 4: Answer always ends with [Source: <filename>, Section <X.Y>].
+
+    Error handling (skills.md):
+      - ValueError if index is empty or None.
+      - Cross-document ambiguity → is_refusal=True.
+    """
+    if not index:
+        raise ValueError("Document index is empty - run retrieve_documents first.")
+
+    tokens = set(
+        w.lower().strip(string.punctuation)
+        for w in question.split()
+        if w.lower().strip(string.punctuation) not in STOP_WORDS
+        and len(w.strip(string.punctuation)) > 2
+    )
+
+    if not tokens:
+        return {"answer": REFUSAL_TEMPLATE, "source_doc": None,
+                "source_section": None, "is_refusal": True}
+
+    # Score every section by keyword overlap
+    scored = []
+    for doc_name, section_id, text in flat:
+        hits = sum(1 for t in tokens if t in text.lower())
+        if hits > 0:
+            scored.append((hits, doc_name, section_id, text))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    if not scored:
+        return {"answer": REFUSAL_TEMPLATE, "source_doc": None,
+                "source_section": None, "is_refusal": True}
+
+    top_score   = scored[0][0]
+    top_matches = [s for s in scored if s[0] == top_score]
+    top_docs    = {m[1] for m in top_matches}
+
+    # Enforcement rule 1: tie across multiple documents → refuse
+    if len(top_docs) > 1:
+        return {"answer": REFUSAL_TEMPLATE, "source_doc": None,
+                "source_section": None, "is_refusal": True}
+
+    _, doc_name, section_id, section_text = scored[0]
+
+    # Enforcement rule 2: strip forbidden phrases (safety guard)
+    answer_text = section_text
+    for phrase in FORBIDDEN_PHRASES:
+        answer_text = re.sub(re.escape(phrase), "[REDACTED]", answer_text,
+                             flags=re.IGNORECASE)
+
+    # Enforcement rule 4: append citation
+    full_answer = answer_text + f"\n\n[Source: {doc_name}, Section {section_id}]"
+
+    return {"answer": full_answer, "source_doc": doc_name,
+            "source_section": section_id, "is_refusal": False}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Interactive CLI
+# ─────────────────────────────────────────────────────────────────────────────
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    print("=" * 60)
+    print("  UC-X — Ask My Documents  (CMC Policy Q&A Agent)")
+    print("=" * 60)
+    print("Loading policy documents...")
+
+    file_paths = [os.path.join(POLICY_DIR, f) for f in POLICY_FILES]
+
+    try:
+        result = retrieve_documents(file_paths)
+    except FileNotFoundError as e:
+        print(f"\nERROR: {e}")
+        raise SystemExit(1)
+
+    index = result["index"]
+    flat  = result["flat"]
+
+    total_sections = sum(len(v) for v in index.values())
+    print(f"Loaded {len(index)} documents · {total_sections} sections indexed")
+    for doc_name, sections in index.items():
+        print(f"  {doc_name}: {len(sections)} sections")
+
+    print("\nType your question and press Enter. Type 'quit' or 'exit' to stop.\n")
+
+    while True:
+        try:
+            question = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye.")
+            break
+
+        if not question:
+            continue
+        if question.lower() in ("quit", "exit", "q"):
+            print("Goodbye.")
+            break
+
+        result = answer_question(question, index, flat)
+
+        print()
+        if result["is_refusal"]:
+            print("Agent [REFUSAL]:")
+        else:
+            print(f"Agent [Source: {result['source_doc']}, Section {result['source_section']}]:")
+        print(result["answer"])
+        print()
+
 
 if __name__ == "__main__":
     main()

--- a/uc-x/skills.md
+++ b/uc-x/skills.md
@@ -1,16 +1,56 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md - UC-X Ask My Documents
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_documents
+    description: >
+      Loads all three CMC policy text files and indexes their content by document
+      name and section number, making each section individually addressable for
+      lookup by the answer_question skill.
+    input: >
+      A list of file paths (strings) - the three policy documents:
+        - ../data/policy-documents/policy_hr_leave.txt
+        - ../data/policy-documents/policy_it_acceptable_use.txt
+        - ../data/policy-documents/policy_finance_reimbursement.txt
+    output: >
+      A dict (the index) with structure:
+        {
+          "<document_filename>": {
+            "<section_number>": "<full section text>",
+            ...
+          },
+          ...
+        }
+      Each section is keyed by its dotted number (e.g. "2.6", "5.2") and contains
+      the complete unmodified text of that section from the source file.
+      Also returns a flat list of (doc_name, section_id, text) tuples for search.
+    error_handling: >
+      If any file cannot be read, raise FileNotFoundError naming the missing file.
+      If a section cannot be parsed into a numbered section, store it under key
+      "UNSTRUCTURED" so it is never silently lost. Log a warning for any file
+      where zero numbered sections were found.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: answer_question
+    description: >
+      Searches the indexed documents for sections relevant to the question and
+      returns a single-source answer with citation, or the exact refusal template
+      if the question is not covered in the documents.
+    input: >
+      Two arguments:
+        - question (str)  - the employee's natural language question
+        - index    (dict) - the document index returned by retrieve_documents
+    output: >
+      A dict with keys:
+        - answer         (str)       - the answer text using only source document
+                                       wording, followed by [Source: <filename>,
+                                       Section <X.Y>], OR the exact refusal
+                                       template if not found
+        - source_doc     (str|None)  - the document filename the answer came from,
+                                       None if refusal
+        - source_section (str|None)  - the section number cited, None if refusal
+        - is_refusal     (bool)      - True if the refusal template was returned
+    error_handling: >
+      If the question matches sections in more than one document and the sections
+      cannot be answered from a single source without blending, set is_refusal=True
+      and return the refusal template - never blend cross-document results.
+      If the index is empty or None, raise ValueError: "Document index is empty -
+      run retrieve_documents first." Never attempt to answer without a loaded index.


### PR DESCRIPTION
## Pull Request

**Commit formula:** `UC-0X Fix [failure mode]: [why it failed] → [what you changed]`

---

### Use Case(s) Changed

- [ ] UC-0A — Complaint Classifier
- [ ] UC-0B — Policy Summarisation
- [ ] UC-0C — Budget Growth Analysis
- [ ] UC-X  — Policy Q&A

---

### Description

<!-- What changed and why? Link to any issue or README section if relevant. -->

---

### UC-0A — Complaint Classifier checklist

> Skip if UC-0A is not changed.

- [ ] Category string matches one of the 10 allowed values exactly (case-sensitive)
- [ ] `URGENT` priority is only triggered by a recognised urgent keyword
- [ ] `reason` field is populated for every row; never empty
- [ ] Rows that cannot be classified with confidence are flagged `NEEDS_REVIEW`
- [ ] `batch_classify` tested against at least one city CSV; row count matches input

---

### UC-0B — Policy Summarisation checklist

> Skip if UC-0B is not changed.

- [ ] All 10 required clauses (2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2) are present in output
- [ ] Clause 5.2 names both approvers as written in the source document
- [ ] Binding verbs (`must`, `shall`, `will not`) are preserved; not softened to `may` / `can`
- [ ] Verbatim marker `[VERBATIM - summarisation would alter meaning]` applied to all verbatim clauses
- [ ] Output file written to the path supplied via `--output`

---

### UC-0C — Budget Growth Analysis checklist

> Skip if UC-0C is not changed.

- [ ] Growth type is `MoM` or `YoY`; any other value is refused with a clear error
- [ ] Null / missing spend rows are flagged in output with a note; not silently dropped
- [ ] Formula string shown for every computed period (e.g. `(current - prev) / prev * 100`)
- [ ] No aggregation across wards or categories is performed
- [ ] Reference values pass: Ward 1 MoM +33.11 % (2024-07) and −34.83 % (2024-10)

---

### UC-X — Policy Q&A checklist

> Skip if UC-X is not changed.

- [ ] Answer cites exactly one source document and section; no cross-document blending
- [ ] Refusal template used verbatim when the question spans multiple documents
- [ ] No forbidden hedging phrases (`it depends`, `generally`, `typically`, `in most cases`, `usually`, `it is possible`) appear in any answer
- [ ] Every factual claim includes a `source_doc` + `source_section` citation
- [ ] `is_refusal` flag is `True` only when a cross-document question is detected

---

### Testing

| Use Case | Test command run | Outcome |
|----------|-----------------|---------|
| UC-0A | `python3 classifier.py --input ../data/city-test-files/test_pune.csv --output results_pune.csv` | |
| UC-0B | `python3 app.py --input ../data/policy-documents/policy_hr_leave.txt --output summary_hr_leave.txt` | |
| UC-0C | `python3 app.py --input ../data/budget/ward_budget.csv --ward "Ward 1 – Kasba" --category "Roads & Pothole Repair" --growth-type MoM --output growth_output.csv` | |
| UC-X  | Interactive CLI — tested at least 3 single-doc questions and 1 cross-doc question | |

---

### Reviewer notes

<!-- Anything the reviewer should pay special attention to. -->
