### PR TITLE
Add HR summarizer app, update agents/skills docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ __pycache__/
 *.pyc
 .venv/
 tutor-only/
+uc-0b/agents.md
+uc-0b/agents.md
+uc-0b/app.py
+uc-0b/skills.md

--- a/data/budget/growth_output.csv
+++ b/data/budget/growth_output.csv
@@ -1,0 +1,13 @@
+ward,category,period,budgeted_amount,actual_spend,MoM_Growth,Formula,notes
+Ward 1 – Kasba,Roads & Pothole Repair,2024-01,13.0,13.3,N/A,N/A (No previous month data),
+Ward 1 – Kasba,Roads & Pothole Repair,2024-02,13.0,12.2,-8.3%,((12.2 - 13.3) / 13.3) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-03,13.0,12.3,+0.8%,((12.3 - 12.2) / 12.2) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-04,13.0,13.4,+8.9%,((13.4 - 12.3) / 12.3) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-05,13.0,14.1,+5.2%,((14.1 - 13.4) / 13.4) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-06,13.0,14.8,+5.0%,((14.8 - 14.1) / 14.1) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-07,13.0,19.7,+33.1%,((19.7 - 14.8) / 14.8) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-08,13.0,20.2,+2.5%,((20.2 - 19.7) / 19.7) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-09,13.0,20.1,-0.5%,((20.1 - 20.2) / 20.2) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-10,13.0,13.1,-34.8%,((13.1 - 20.1) / 20.1) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-11,13.0,14.2,+8.4%,((14.2 - 13.1) / 13.1) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-12,13.0,12.7,-10.6%,((12.7 - 14.2) / 14.2) * 100,

--- a/data/policy-documents/policy_hr_leave.txt
+++ b/data/policy-documents/policy_hr_leave.txt
@@ -5,7 +5,7 @@ Document Reference: HR-POL-001
 Version: 2.3 | Effective: 1 April 2024
 
 ═══════════════════════════════════════════════════════════
-1. PURPOSE AND SCOPE
+1. PURPOSE AND SCOPE   
 ═══════════════════════════════════════════════════════════
 1.1 This policy governs all leave entitlements for permanent and
     contractual employees of the City Municipal Corporation (CMC).

--- a/data/policy-documents/summary_hr_leave.txt
+++ b/data/policy-documents/summary_hr_leave.txt
@@ -1,0 +1,31 @@
+Summary of HR Leave Policy (HR-POL-001)
+
+1.1 This policy governs leave entitlements for permanent and contractual CMC employees.
+1.2 Policy does not apply to daily wage workers or consultants; governed by their own contracts.
+2.1 Permanent employees get 18 paid annual leave days per calendar year.
+2.2 Annual leave accrues at 1.5 days/month from joining date.
+2.3 Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+2.4 [VERBATIM] "Leave applications must receive written approval from the employee's direct manager before the leave commences. Verbal approval is not valid." (Flag: Cannot be summarized without meaning loss)
+2.5 [VERBATIM] "Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval." (Flag: Cannot be summarized without meaning loss)
+2.6 Employees may carry forward max 5 unused annual leave days to the following year. Days above 5 are forfeited on 31 December.
+2.7 Carry-forward days must be used within Q1 (Jan–Mar) of the following year or they are forfeited.
+3.1 Employees get 12 paid sick leave days per calendar year.
+3.2 Sick leave of 3 or more consecutive days requires a medical certificate from a registered practitioner, submitted within 48 hours of return.
+3.3 Sick leave cannot be carried forward.
+3.4 Sick leave taken immediately before or after a public holiday or annual leave requires a medical certificate regardless of duration.
+4.1 Female employees get 26 weeks paid maternity leave for the first two live births.
+4.2 For a third or subsequent child, maternity leave is 12 weeks paid.
+4.3 Male employees get 5 days of paid paternity leave, taken within 30 days of the child's birth.
+4.4 Paternity leave cannot be split across multiple periods.
+5.1 LWP may only be applied for after exhausting all paid leave entitlements.
+5.2 LWP requires approval from BOTH the Department Head and the HR Director. Manager approval alone is not sufficient.
+5.3 LWP over 30 continuous days requires approval from the Municipal Commissioner.
+5.4 LWP does not count toward service for seniority, increments, or retirement benefits.
+6.1 Employees are entitled to all gazetted public holidays declared by the State Government.
+6.2 If required to work on a public holiday, employees get one compensatory off, taken within 60 days of the worked holiday.
+6.3 Compensatory off cannot be encashed.
+7.1 Annual leave may be encashed only at retirement or resignation, subject to a maximum of 60 days.
+7.2 Leave encashment during service is not permitted under any circumstances.
+7.3 Sick leave and LWP cannot be encashed under any circumstances.
+8.1 Leave-related grievances must be raised with HR within 10 working days of the disputed decision.
+8.2 Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.

--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,14 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
-
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are an HR Policy Summarization Agent. Your operational boundary is strict document summarization; you are not permitted to interpret, soften, or omit any binding obligations.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output must contain all required clauses present in the original document, preserving all conditions and multi-approver requirements accurately, formatted as a clear and verifiable summary with clause references.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  You may only use the provided policy document. You are explicitly excluded from using outside knowledge, standard practices, or general government expectations not found in the source text.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause must be present in the summary."
+  - "Multi-condition obligations must preserve ALL conditions — never drop one silently."
+  - "Never add information not present in the source document."
+  - "If a clause cannot be summarised without meaning loss — quote it verbatim and flag it."

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,72 @@
 """
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0B app.py — LLM implementation for HR policy summarization.
 """
 import argparse
+import os
+import sys
+
+try:
+    import google.generativeai as genai
+except ImportError:
+    print("Please install google-generativeai package: pip install google-generativeai")
+    sys.exit(1)
+
+def retrieve_policy(filepath: str) -> str:
+    """Skill 1: Retrieve policy document."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        return f.read()
+
+def summarize_policy(policy_text: str) -> str:
+    """Skill 2: Summarize using AI based on RICE enforcement."""
+    # Ensure API key is set
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY environment variable not set. Please set it before running.")
+        
+    genai.configure(api_key=api_key)
+    
+    # RICE Context from agents.md
+    system_instruction = '''
+role: >
+  You are an HR Policy Summarization Agent. Your operational boundary is strict document summarization; you are not permitted to interpret, soften, or omit any binding obligations.
+
+intent: >
+  A correct output must contain all required clauses present in the original document, preserving all conditions and multi-approver requirements accurately, formatted as a clear and verifiable summary with clause references.
+
+context: >
+  You may only use the provided policy document. You are explicitly excluded from using outside knowledge, standard practices, or general government expectations not found in the source text.
+
+enforcement:
+  - "Every numbered clause must be present in the summary."
+  - "Multi-condition obligations must preserve ALL conditions — never drop one silently."
+  - "Never add information not present in the source document."
+  - "If a clause cannot be summarised without meaning loss — quote it verbatim and flag it."
+'''
+    model = genai.GenerativeModel('gemini-2.5-flash', system_instruction=system_instruction)
+    response = model.generate_content(f"Summarize the following policy document according to your strict instructions:\n\n{policy_text}")
+    return response.text
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0B HR Policy Summarizer")
+    parser.add_argument("--input", required=True, help="Path to policy_hr_leave.txt")
+    parser.add_argument("--output", required=True, help="Path to write the summary txt")
+    args = parser.parse_args()
+    
+    try:
+        policy_content = retrieve_policy(args.input)
+        print("Policy retrieved successfully. Summarizing using AI...")
+        summary = summarize_policy(policy_content)
+        
+        # Ensure output directory exists just in case
+        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+        
+        with open(args.output, 'w', encoding='utf-8') as f:
+            f.write(summary)
+            
+        print(f"Done. Summary written to {args.output}")
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -6,9 +6,10 @@ import os
 import sys
 
 try:
-    import google.generativeai as genai
+    from google import genai
+    from google.genai import types
 except ImportError:
-    print("Please install google-generativeai package: pip install google-generativeai")
+    print("Please install google-genai package: pip install google-genai")
     sys.exit(1)
 
 def retrieve_policy(filepath: str) -> str:
@@ -21,9 +22,11 @@ def summarize_policy(policy_text: str) -> str:
     # Ensure API key is set
     api_key = os.environ.get("GEMINI_API_KEY")
     if not api_key:
-        raise ValueError("GEMINI_API_KEY environment variable not set. Please set it before running.")
+        api_key = input("GEMINI_API_KEY not found. Please enter your API key: ").strip()
+        if not api_key:
+            raise ValueError("GEMINI_API_KEY environment variable not set. Please set it before running.")
         
-    genai.configure(api_key=api_key)
+    client = genai.Client(api_key=api_key)
     
     # RICE Context from agents.md
     system_instruction = '''
@@ -42,8 +45,13 @@ enforcement:
   - "Never add information not present in the source document."
   - "If a clause cannot be summarised without meaning loss — quote it verbatim and flag it."
 '''
-    model = genai.GenerativeModel('gemini-2.5-flash', system_instruction=system_instruction)
-    response = model.generate_content(f"Summarize the following policy document according to your strict instructions:\n\n{policy_text}")
+    response = client.models.generate_content(
+        model='gemini-2.5-flash',
+        contents=f"Summarize the following policy document according to your strict instructions:\n\n{policy_text}",
+        config=types.GenerateContentConfig(
+            system_instruction=system_instruction,
+        )
+    )
     return response.text
 
 def main():
@@ -58,7 +66,9 @@ def main():
         summary = summarize_policy(policy_content)
         
         # Ensure output directory exists just in case
-        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+        output_dir = os.path.dirname(os.path.abspath(args.output))
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
         
         with open(args.output, 'w', encoding='utf-8') as f:
             f.write(summary)

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,12 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
-
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Opens and reads a local .txt policy file, returning its entire text content.
+    input: File path (string).
+    output: Full text of the document as a string.
+    error_handling: Raises FileNotFoundError if the file is missing or inaccessible.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Processes the policy text through an LLM using the strict enforcement rules in agents.md to produce a completely compliant summary.
+    input: The full text of the policy document (string).
+    output: A summarized text document (string) containing every required clause and condition.
+    error_handling: Returns an error message if the LLM output is empty or if the API call fails.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,31 @@
+Summary of HR Leave Policy (HR-POL-001)
+
+1.1 This policy governs leave entitlements for permanent and contractual CMC employees.
+1.2 Policy does not apply to daily wage workers or consultants; governed by their own contracts.
+2.1 Permanent employees get 18 paid annual leave days per calendar year.
+2.2 Annual leave accrues at 1.5 days/month from joining date.
+2.3 Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+2.4 [VERBATIM] "Leave applications must receive written approval from the employee's direct manager before the leave commences. Verbal approval is not valid." (Flag: Cannot be summarized without meaning loss)
+2.5 [VERBATIM] "Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval." (Flag: Cannot be summarized without meaning loss)
+2.6 Employees may carry forward max 5 unused annual leave days to the following year. Days above 5 are forfeited on 31 December.
+2.7 Carry-forward days must be used within Q1 (Jan–Mar) of the following year or they are forfeited.
+3.1 Employees get 12 paid sick leave days per calendar year.
+3.2 Sick leave of 3 or more consecutive days requires a medical certificate from a registered practitioner, submitted within 48 hours of return.
+3.3 Sick leave cannot be carried forward.
+3.4 Sick leave taken immediately before or after a public holiday or annual leave requires a medical certificate regardless of duration.
+4.1 Female employees get 26 weeks paid maternity leave for the first two live births.
+4.2 For a third or subsequent child, maternity leave is 12 weeks paid.
+4.3 Male employees get 5 days of paid paternity leave, taken within 30 days of the child's birth.
+4.4 Paternity leave cannot be split across multiple periods.
+5.1 LWP may only be applied for after exhausting all paid leave entitlements.
+5.2 LWP requires approval from BOTH the Department Head and the HR Director. Manager approval alone is not sufficient.
+5.3 LWP over 30 continuous days requires approval from the Municipal Commissioner.
+5.4 LWP does not count toward service for seniority, increments, or retirement benefits.
+6.1 Employees are entitled to all gazetted public holidays declared by the State Government.
+6.2 If required to work on a public holiday, employees get one compensatory off, taken within 60 days of the worked holiday.
+6.3 Compensatory off cannot be encashed.
+7.1 Annual leave may be encashed only at retirement or resignation, subject to a maximum of 60 days.
+7.2 Leave encashment during service is not permitted under any circumstances.
+7.3 Sick leave and LWP cannot be encashed under any circumstances.
+8.1 Leave-related grievances must be raised with HR within 10 working days of the disputed decision.
+8.2 Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.

--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -3,16 +3,16 @@
 # Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a strict financial data processor and calculator. You only compute requested metrics at the exact granularity provided, without ever making assumptions about missing data or unspecified parameters.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  You will ingest structured budget data, validate it, handle missing values transparently by flagging them, and compute specific metrics (like MoM growth) for a specified ward and category. A correct output is a per-ward per-category table containing the computed metric and explicitly showing the formula used for each row.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  You are allowed to use the provided CSV data file. You must NOT use external financial info or make up budget data. You must NOT assume any default growth calculation without explicit instruction.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never aggregate across wards or categories unless explicitly instructed — refuse if asked."
+  - "Flag every null row before computing — report null reason from the notes column."
+  - "Show formula used in every output row alongside the result."
+  - "If `--growth-type` not specified — refuse and ask, never guess."

--- a/uc-0c/app.py
+++ b/uc-0c/app.py
@@ -1,12 +1,131 @@
-"""
-UC-0C app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
-"""
 import argparse
+import csv
+import sys
+
+def load_dataset(input_path):
+    """
+    Reads CSV, validates columns, reports null count and which rows before returning.
+    """
+    try:
+        with open(input_path, 'r', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            data = list(reader)
+    except FileNotFoundError:
+        print(f"Error: Input file {input_path} not found.")
+        sys.exit(1)
+        
+    expected_cols = {'period', 'ward', 'category', 'budgeted_amount', 'actual_spend', 'notes'}
+    if not expected_cols.issubset(set(reader.fieldnames)):
+        print(f"Error: Missing expected columns. Found: {reader.fieldnames}")
+        sys.exit(1)
+
+    # Flag and report nulls globally as requested by the rule
+    null_rows = []
+    for i, row in enumerate(data, start=2): # 1-indexed plus header
+        if not row['actual_spend'] or row['actual_spend'].strip() == '':
+            null_rows.append((i, row['ward'], row['category'], row['period'], row.get('notes', '')))
+    
+    if null_rows:
+        print(f"Data Validation: Found {len(null_rows)} explicitly null `actual_spend` records.")
+        for r in null_rows:
+            print(f"  - Row {r[0]}: {r[3]} | {r[1]} | {r[2]} -> NULL Reason: {r[4]}")
+            
+    return data
+
+def compute_growth(data, ward, category, growth_type):
+    """
+    Takes ward + category + growth_type, returns per-period table with formula shown.
+    """
+    if ward is None or category is None:
+        raise ValueError("REFUSAL: Never aggregate across wards or categories unless explicitly instructed. Please provide both --ward and --category.")
+    
+    if growth_type is None:
+        raise ValueError("REFUSAL: If `--growth-type` not specified — refuse and ask, never guess.")
+    
+    if growth_type != 'MoM':
+        raise ValueError(f"REFUSAL: Growth type '{growth_type}' is not supported yet. Only 'MoM' is implemented.")
+        
+    # Filter for the specific ward and category
+    filtered = [row for row in data if row['ward'] == ward and row['category'] == category]
+    
+    if not filtered:
+        print(f"Warning: No data found for Ward: '{ward}', Category: '{category}'")
+    
+    # Sort by period just in case
+    filtered.sort(key=lambda x: x['period'])
+    
+    results = []
+    prev_spend = None
+    
+    for row in filtered:
+        period = row['period']
+        actual = row['actual_spend'].strip() if row['actual_spend'] else None
+        notes = row.get('notes', '').strip()
+        
+        result_row = {
+            'ward': ward,
+            'category': category,
+            'period': period,
+            'budgeted_amount': row['budgeted_amount'],
+            'actual_spend': actual if actual else 'NULL',
+            'notes': notes
+        }
+        
+        if not actual:
+            # Null row encountered
+            result_row['MoM_Growth'] = 'NULL'
+            result_row['Formula'] = f"FLAGGED NULL -> Reason: {notes}"
+            prev_spend = None # Break the chain for the next month
+        else:
+            current_spend = float(actual)
+            if prev_spend is None:
+                result_row['MoM_Growth'] = 'N/A'
+                result_row['Formula'] = "N/A (No previous month data)"
+            else:
+                growth_pct = ((current_spend - prev_spend) / prev_spend) * 100
+                result_row['MoM_Growth'] = f"{growth_pct:+.1f}%"
+                result_row['Formula'] = f"(({current_spend} - {prev_spend}) / {prev_spend}) * 100"
+                if notes:
+                    result_row['MoM_Growth'] += f" ({notes})"
+            
+            prev_spend = current_spend
+            
+        results.append(result_row)
+        
+    return results
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="Strict financial data processor and calculator.")
+    parser.add_argument('--input', help='Path to the input CSV file')
+    parser.add_argument('--ward', help='Specific ward to filter on (Required to prevent aggregation)')
+    parser.add_argument('--category', help='Specific category to filter on (Required to prevent aggregation)')
+    parser.add_argument('--growth-type', help='Type of growth to compute (e.g., MoM)')
+    parser.add_argument('--output', help='Path to save the computed output CSV')
+    
+    args = parser.parse_args()
+    
+    if not args.input or not args.output:
+        print("Error: --input and --output are required.", file=sys.stderr)
+        sys.exit(1)
+        
+    try:
+        data = load_dataset(args.input)
+        results = compute_growth(data, args.ward, args.category, args.growth_type)
+        
+        # Write the per-period per-ward per-category table to output
+        with open(args.output, 'w', newline='', encoding='utf-8') as f:
+            if results:
+                fieldnames = ['ward', 'category', 'period', 'budgeted_amount', 'actual_spend', 'MoM_Growth', 'Formula', 'notes']
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(results)
+                print(f"Success: Wrote {len(results)} rows to {args.output}")
+            else:
+                print(f"Warning: No valid records to write to {args.output}")
 
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+        
 if __name__ == "__main__":
     main()

--- a/uc-0c/growth_output.csv
+++ b/uc-0c/growth_output.csv
@@ -1,0 +1,13 @@
+ward,category,period,budgeted_amount,actual_spend,MoM_Growth,Formula,notes
+Ward 1 – Kasba,Roads & Pothole Repair,2024-01,13.0,13.3,N/A,N/A (No previous month data),
+Ward 1 – Kasba,Roads & Pothole Repair,2024-02,13.0,12.2,-8.3%,((12.2 - 13.3) / 13.3) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-03,13.0,12.3,+0.8%,((12.3 - 12.2) / 12.2) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-04,13.0,13.4,+8.9%,((13.4 - 12.3) / 12.3) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-05,13.0,14.1,+5.2%,((14.1 - 13.4) / 13.4) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-06,13.0,14.8,+5.0%,((14.8 - 14.1) / 14.1) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-07,13.0,19.7,+33.1%,((19.7 - 14.8) / 14.8) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-08,13.0,20.2,+2.5%,((20.2 - 19.7) / 19.7) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-09,13.0,20.1,-0.5%,((20.1 - 20.2) / 20.2) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-10,13.0,13.1,-34.8%,((13.1 - 20.1) / 20.1) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-11,13.0,14.2,+8.4%,((14.2 - 13.1) / 13.1) * 100,
+Ward 1 – Kasba,Roads & Pothole Repair,2024-12,13.0,12.7,-10.6%,((12.7 - 14.2) / 14.2) * 100,

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -3,14 +3,14 @@
 # Delete these comments before committing.
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: Reads CSV, validates columns, reports null count and which rows before returning.
+    input: file_path (string)
+    output: A tuple of (validated_data (list of dicts), null_report (string))
+    error_handling: Raises specific errors if the file is missing or columns are malformed. Reports exact row indices for null values in the actual_spend column.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: compute_growth
+    description: Takes ward + category + growth_type, returns per-period table with formula shown.
+    input: data (list of dicts), ward (string), category (string), growth_type (string)
+    output: A list of dicts with the computed metric (like MoM growth) and the formula shown.
+    error_handling: Refuses to compute if ward/category implies data aggregation or growth_type is missing/unspecified. Flags and refuses computation for null rows.

--- a/uc-x/agents.md
+++ b/uc-x/agents.md
@@ -3,16 +3,20 @@
 # Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a strictly constrained policy assistant for the City Municipal Corporation (CMC). Your operational boundary is exclusively limited to answering questions based directly on the provided policy documents.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output provides a concise, precise, factual answer sourced exclusively from a single document. It must explicitly cite the source document name and the exact section number.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  You may only use the text from the provided policy documents. You are strictly forbidden from using outside knowledge, real-world HR/IT/Finance standard practices, or common sense not explicitly written in the provided text.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never combine claims from two different documents into a single answer."
+  - "Never use hedging phrases: 'while not explicitly covered', 'typically', 'generally understood', 'it is common practice'."
+  - "If the question requires combining information across multiple policies, or if it is ambiguous, refuse to answer."
+  - "Cite source document name + section number for every factual claim."
+  - "If the question is not covered in the documents (or requires refusal due to ambiguity), use the following refusal template EXACTLY, with no variations or additional text:
+This question is not covered in the available policy documents
+(policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt).
+Please contact [relevant team] for guidance."

--- a/uc-x/skills.md
+++ b/uc-x/skills.md
@@ -3,14 +3,14 @@
 # Delete these comments before committing.
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_documents
+    description: Loads all 3 policy files and returns them as a single context string indexed by document name and section number.
+    input: None.
+    output: A string containing the full text of all 3 policies.
+    error_handling: Raises an error if documents are missing or cannot be read.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: answer_question
+    description: Searches indexed documents and returns a single-source answer with citation OR the refusal template.
+    input: The user's question (string) and the retrieved policy text (string).
+    output: A string containing the answer with citation, or the exact refusal template.
+    error_handling: Returns the exact refusal template if there is any ambiguity, if the answer is not found, or if it requires cross-document blending.


### PR DESCRIPTION
Add a CLI LLM-based HR policy summarizer (uc-0b/app.py) with retrieve_policy and summarize_policy functions, Gemini API integration (google-generativeai), GEMINI_API_KEY validation, and basic error handling. Flesh out uc-0b/agents.md with a strict HR Policy Summarization Agent role, intent, context restrictions, and enforcement rules. Update uc-0b/skills.md to document retrieve_policy and summarize_policy skills and their I/O/error behavior. Update .gitignore to ignore the uc-0b docs and app files.