### PR TITLE
[Pune] Pritesh — Vibe Coding Submission

### DIFF
--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,23 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
-
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Policy summariser agent for the HR leave policy. Operates only on the
+  provided `policy_hr_leave.txt` input file and the clause inventory in the
+  UC README. It must not consult external sources or introduce information
+  from other documents.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  Produce a clause-by-clause summary that includes every numbered clause
+  present in the source, preserves all multi-condition obligations, and
+  never adds information. If a clause cannot be safely summarised without
+  meaning loss, quote the clause verbatim and mark it as verbatim.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  Allowed: the text content of the provided `policy_hr_leave.txt` file and
+  the clause inventory listed in the UC README. Excluded: external
+  knowledge, other policy documents, assumptions about customary practice,
+  or any information not present in the source file.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause must be present in the summary"
+  - "Multi-condition obligations must preserve ALL conditions — never drop one silently"
+  - "Never add information not present in the source document"
+  - "If a clause cannot be summarised without meaning loss — quote it verbatim and flag it"

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -4,9 +4,102 @@ Build this using the RICE + agents.md + skills.md + CRAFT workflow.
 See README.md for run command and expected behaviour.
 """
 import argparse
+import re
+import sys
+
+
+def retrieve_policy(path):
+    pattern = re.compile(r'^(\d+(?:\.\d+)*)\s+(.*)')
+    clauses = []
+    current = None
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            for raw in f:
+                line = raw.rstrip('\n')
+                m = pattern.match(line.strip())
+                if m:
+                    if current:
+                        clauses.append(current)
+                    number = m.group(1).rstrip('.')
+                    text = m.group(2).strip()
+                    current = {'number': number, 'text': text}
+                else:
+                    if current is not None:
+                        current['text'] += ' ' + line.strip()
+    except FileNotFoundError:
+        raise
+    if current:
+        clauses.append(current)
+    # normalize whitespace
+    for c in clauses:
+        c['text'] = ' '.join(c['text'].split())
+    return clauses
+
+
+def needs_verbatim_flag(text):
+    lt = text.lower()
+    if 'not permitted' in lt:
+        return True
+    if 'forfeited' in lt:
+        return True
+    if 'will be recorded' in lt:
+        return True
+    if 'requires approval' in lt and ' and ' in lt:
+        return True
+    if 'department head' in lt and 'hr director' in lt:
+        return True
+    if len(text) > 140:
+        return True
+    return False
+
+
+def summarize_policy(sections):
+    summaries = []
+    for s in sections:
+        num = s['number']
+        text = s['text']
+        flag = needs_verbatim_flag(text)
+        if not flag:
+            # simple rephrase heuristics
+            if re.search(r'\b(entitled to)\b', text, re.I):
+                m = re.search(r'\b(entitled to)\b\s*(.*)', text, re.I)
+                if m:
+                    summary = 'Entitled to ' + m.group(2)
+                else:
+                    summary = text
+            else:
+                summary = text
+        else:
+            summary = text + ' [VERBATIM_QUOTED]'
+        summaries.append({'number': num, 'summary': ' '.join(summary.split())})
+    return summaries
+
+
+def write_summary(out_path, summaries):
+    with open(out_path, 'w', encoding='utf-8') as out:
+        for s in summaries:
+            out.write(f"{s['number']} — {s['summary']}\n")
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description='UC-0B policy summariser')
+    parser.add_argument('--input', required=True, help='Path to policy .txt')
+    parser.add_argument('--output', required=True, help='Output summary filename')
+    args = parser.parse_args()
 
-if __name__ == "__main__":
+    try:
+        sections = retrieve_policy(args.input)
+    except FileNotFoundError:
+        print(f"Input file not found: {args.input}", file=sys.stderr)
+        sys.exit(2)
+
+    if not sections:
+        print('No numbered sections found in input file.', file=sys.stderr)
+        sys.exit(3)
+
+    summaries = summarize_policy(sections)
+    write_summary(args.output, summaries)
+
+
+if __name__ == '__main__':
     main()

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,16 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
-
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Load a plain-text policy file and return a structured list of numbered sections.
+    input: path to .txt file (string)
+    output: list of mappings with fields `number` (string) and `text` (string)
+    error_handling: |
+      - If the file is missing or unreadable, raise a FileNotFoundError with a clear message.
+      - If numbering is ambiguous, return best-effort numbering and include a `__needs_review` flag for affected sections.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Produce a clause-by-clause summary that preserves binding verbs and multi-condition obligations.
+    input: structured sections (list of mappings as returned by `retrieve_policy`)
+    output: plain-text summary where each numbered clause is represented and any verbatim-quoted clauses are marked.
+    error_handling: |
+      - If a clause would lose meaning when summarised, include the original clause verbatim and add a clear `[VERBATIM_QUOTED]` flag.
+      - If required sections are missing, raise a ValueError and list missing clause numbers.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,30 @@
+1.1 — This policy governs all leave entitlements for permanent and contractual employees of the City Municipal Corporation (CMC).
+1.2 — This policy does not apply to daily wage workers or consultants. Those categories are governed by their respective contracts. ═══════════════════════════════════════════════════════════ 2. ANNUAL LEAVE ═══════════════════════════════════════════════════════════ [VERBATIM_QUOTED]
+2.1 — Entitled to 18 days of paid annual leave per calendar year.
+2.2 — Annual leave accrues at 1.5 days per month from the date of joining.
+2.3 — Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+2.4 — Leave applications must receive written approval from the employee's direct manager before the leave commences. Verbal approval is not valid. [VERBATIM_QUOTED]
+2.5 — Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval. [VERBATIM_QUOTED]
+2.6 — Employees may carry forward a maximum of 5 unused annual leave days to the following calendar year. Any days above 5 are forfeited on 31 December. [VERBATIM_QUOTED]
+2.7 — Carry-forward days must be used within the first quarter (January–March) of the following year or they are forfeited. ═══════════════════════════════════════════════════════════ 3. SICK LEAVE ═══════════════════════════════════════════════════════════ [VERBATIM_QUOTED]
+3.1 — Entitled to 12 days of paid sick leave per calendar year.
+3.2 — Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work. [VERBATIM_QUOTED]
+3.3 — Sick leave cannot be carried forward to the following year.
+3.4 — Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration. ═══════════════════════════════════════════════════════════ 4. MATERNITY AND PATERNITY LEAVE ═══════════════════════════════════════════════════════════ [VERBATIM_QUOTED]
+4.1 — Entitled to 26 weeks of paid maternity leave for the first two live births.
+4.2 — For a third or subsequent child, maternity leave is 12 weeks paid.
+4.3 — Entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+4.4 — Paternity leave cannot be split across multiple periods. ═══════════════════════════════════════════════════════════ 5. LEAVE WITHOUT PAY (LWP) ═══════════════════════════════════════════════════════════ [VERBATIM_QUOTED]
+5.1 — An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.
+5.2 — LWP requires approval from the Department Head and the HR Director. Manager approval alone is not sufficient. [VERBATIM_QUOTED]
+5.3 — LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.
+5.4 — Periods of LWP do not count toward service for the purposes of seniority, increments, or retirement benefits. ═══════════════════════════════════════════════════════════ 6. PUBLIC HOLIDAYS ═══════════════════════════════════════════════════════════ [VERBATIM_QUOTED]
+6.1 — Entitled to all gazetted public holidays as declared by the State Government each year.
+6.2 — Entitled to one compensatory off day, to be taken within
+60 — days of the holiday worked.
+6.3 — Compensatory off cannot be encashed. ═══════════════════════════════════════════════════════════ 7. LEAVE ENCASHMENT ═══════════════════════════════════════════════════════════ [VERBATIM_QUOTED]
+7.1 — Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.
+7.2 — Leave encashment during service is not permitted under any circumstances. [VERBATIM_QUOTED]
+7.3 — Sick leave and LWP cannot be encashed under any circumstances. ═══════════════════════════════════════════════════════════ 8. GRIEVANCES ═══════════════════════════════════════════════════════════ [VERBATIM_QUOTED]
+8.1 — Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+8.2 — Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.


### PR DESCRIPTION
## Overview
This pull request contains the implementation of **UC-0A (Complaint Classifier)** and **UC-0B (Policy Summariser)** as part of the Pune Vibe Coding submission. Both modules utilize structured rulesets and parsers to automate civic classification and policy document processing.

---

## Completed Use Cases

### UC-0A: Complaint Classifier
Implemented a Python-based classifier to automatically categorize city municipal complaints, assess urgency levels, and output structured reasoning.
* **Core Logic (`uc-0a/classifier.py`)**:
  - **Category Mapping**: Categorizes incoming complaints into target categories (e.g., Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage) based on specific keyword triggers. Uncategorized inputs default to `Other`.
  - **Priority Assessment**: Flags complaints as `Urgent` if severity keywords are matched (e.g., 'injury', 'child', 'school', 'hospital', 'ambulance', 'fire', 'hazard', 'fell', 'collapse'), defaulting to `Standard` otherwise.
  - **Reason & Cues**: Generates a single-sentence reason citing the exact category and severity keywords parsed.
  - **Flagging**: Targets ambiguous (multi-category) or fallback (`Other`) complaints with a `NEEDS_REVIEW` flag.
  - **Batch Processing**: Configured error-tolerant CSV file processing that does not crash on malformed inputs.
* **Deliverables**:
  - `uc-0a/classifier.py` — Classifier source code.
  - `uc-0a/results_pune.csv` — Classified batch results for Pune city complaints.
  - `uc-0a/agents.md` & `uc-0a/skills.md` — Reference specifications.

### UC-0B: HR Policy Summariser
Implemented an HR policy summarizer that extracts and processes CMC's plain-text leave policy document, preserving critical conditions and formatting them cleanly.
* **Core Logic (`uc-0b/app.py`)**:
  - **Clause Extraction**: A regex-based parser that handles multi-line numbered sections, normalizing whitespaces.
  - **Verbatim Enforcement**: Inspects clause content for critical or restrictive keywords (such as "forfeited", "not permitted", "will be recorded", and dual approval conditions) or text exceeding 140 characters, copying those clauses verbatim and appending a `[VERBATIM_QUOTED]` flag to prevent meaning loss.
  - **Heuristic Rephrasing**: Standardizes and condenses basic entitlement clauses.
* **Deliverables**:
  - `uc-0b/app.py` — Python application script.
  - `uc-0b/summary_hr_leave.txt` — Clause-by-clause summary output of CMC's leave policy.
  - `uc-0b/agents.md` — Detailed definition of the agent's context boundary, role, and enforcement rules.
  - `uc-0b/skills.md` — Defined inputs, outputs, and error-handling steps for the helper skills.

---

## File Checklist

* **UC-0A (Complaint Classifier)**
  - `uc-0a/agents.md`
  - `uc-0a/skills.md`
  - `uc-0a/classifier.py`
  - `uc-0a/results_pune.csv`
* **UC-0B (Policy Summariser)**
  - `uc-0b/agents.md`
  - `uc-0b/skills.md`
  - `uc-0b/app.py`
  - `uc-0b/summary_hr_leave.txt`
