### PR TITLE
[Mumbai] Atharv Deshpande - Vibe Coding Submission

### DIFF
--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,50 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
-
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  An HR policy summarization agent that reads policy_hr_leave.txt from
+  ../data/policy-documents/ and writes a compliant summary to
+  uc-0b/summary_hr_leave.txt using the run command specified for this use case.
+  The agent operates strictly within the bounds of the source document: it
+  uses the retrieve_policy skill to load and structure the policy into
+  numbered sections, then the summarize_policy skill to produce a summary
+  with clause references. It does not act as a general-purpose writer,
+  HR advisor, or policy interpreter beyond faithfully condensing the
+  source text.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a summary saved to uc-0b/summary_hr_leave.txt that
+  accounts for all 10 clauses identified in the clause inventory (2.3, 2.4,
+  2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2). For each clause, the summary must
+  preserve the core obligation and binding verb (must / will / may / are
+  forfeited / requires / not permitted) without changing its legal force —
+  no softening (e.g. "requires" becoming "should" or "is encouraged"), no
+  scope bleed (no added qualifiers, examples, or generalizations not present
+  in the source), and no omission of any condition in multi-condition
+  obligations (e.g. clause 5.2's requirement for approval from BOTH the
+  Department Head AND the HR Director must both appear). Verifiability:
+  reviewers can check the output against the clause inventory table —
+  each clause number should be traceable to a corresponding statement in
+  the summary, every binding verb's strength should match the source, and
+  every multi-part condition should list all parts. Any clause that cannot
+  be summarized without meaning loss must instead be quoted verbatim and
+  flagged as such in the output.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the content of
+  ../data/policy-documents/policy_hr_leave.txt as retrieved via the
+  retrieve_policy skill (returned as structured numbered sections) and the
+  clause inventory derived from it. The agent must not use outside
+  knowledge of HR practices, government leave policies, common
+  organizational norms, or assumptions about "standard practice." The
+  agent must not introduce phrases such as "as is standard practice",
+  "typically in government organisations", or "employees are generally
+  expected to" — or any other content not explicitly present in the source
+  document. The only output the agent should produce is the file at
+  uc-0b/summary_hr_leave.txt.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - Every numbered clause from the clause inventory (2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2) must be present in the summary; no clause may be silently dropped.
+  - Multi-condition obligations must preserve ALL conditions and never drop any condition silently — e.g. clause 5.2 must retain the requirement for approval from BOTH the Department Head AND the HR Director, not just "requires approval".
+  - Never add information not present in the source document, including generalizations, examples, or phrases implying standard practice (e.g. "as is standard practice", "typically in government organisations", "employees are generally expected to").
+  - Binding verb strength must be preserved for each clause (must / will / may / are forfeited / requires / not permitted) — no softening into weaker language such as "should", "is encouraged", or "is recommended".
+  - If a clause cannot be summarised without meaning loss, it must be quoted verbatim from the source and explicitly flagged as a verbatim quote in the output.
+  - The agent must read the input file at ../data/policy-documents/policy_hr_leave.txt and write the output to uc-0b/summary_hr_leave.txt, matching the run command's --input and --output arguments.
+  - The agent must use retrieve_policy to obtain structured numbered sections before invoking summarize_policy, and summarize_policy's output must reference clause numbers.

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,470 @@
+#!/usr/bin/env python3
 """
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+app.py — UC-0B: HR Leave Policy Summarization Agent
+
+Role (agents.md):
+    Reads policy_hr_leave.txt, structures it into numbered clause
+    sections (skill: retrieve_policy), and produces a compliant
+    clause-referenced summary (skill: summarize_policy) written to the
+    output file specified on the command line.
+
+This script is intentionally conservative: every transformation is
+verified against the source clause's binding-verb strength and
+multi-condition terms before it is allowed into the output. If a
+transformation cannot be verified, the clause is emitted verbatim and
+flagged, per enforcement rule 4 in agents.md.
 """
+
 import argparse
+import os
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Ground truth: clause inventory (from README + agents.md context)
+# ---------------------------------------------------------------------------
+
+# Enforcement rule 1: every one of these clauses must be present in the
+# summary; no clause may be silently dropped.
+REQUIRED_CLAUSES = [
+    "2.3", "2.4", "2.5", "2.6", "2.7",
+    "3.2", "3.4", "5.2", "5.3", "7.2",
+]
+
+# Enforcement rule 4 / obligation-softening guard: the binding-verb
+# keyword(s) that MUST survive any compression for a given clause.
+BINDING_VERBS = {
+    "2.3": ["must"],
+    "2.4": ["must"],
+    "2.5": ["will"],
+    "2.6": ["may", "forfeit"],
+    "2.7": ["must", "forfeit"],
+    "3.2": ["require"],
+    "3.4": ["require"],
+    "5.2": ["require"],
+    "5.3": ["require"],
+    "7.2": ["not permitted"],
+}
+
+# Enforcement rule 2: multi-condition obligations whose individual
+# conditions must ALL survive any compression.
+MULTI_CONDITION_TERMS = {
+    "5.2": ["department head", "hr director"],
+}
+
+# Enforcement rule 3 / context: scope-bleed phrases that must never
+# appear in the output because they are not present in the source.
+SCOPE_BLEED_PHRASES = [
+    "as is standard practice",
+    "typically in government organisations",
+    "typically in government organizations",
+    "employees are generally expected to",
+    "generally expected to",
+    "standard practice",
+    "common practice",
+    "best practice",
+]
+
+
+# ---------------------------------------------------------------------------
+# Clause-header parsing
+# ---------------------------------------------------------------------------
+
+# Matches a clean "X.Y" clause header (optionally prefixed with
+# "Clause"/"Section" and followed by punctuation), e.g.:
+#   "2.3 Advance Notice ..."
+#   "Clause 2.4: Written approval ..."
+#   "Section 5.2) LWP requires ..."
+# The negative lookahead prevents matching the first two segments of a
+# longer numbering scheme such as "2.3.1" or "2.34".
+CLAUSE_HEADER_PATTERN = re.compile(
+    r'^(?:Clause\s+|Section\s+)?(\d+\.\d+)(?!\.\d|\d)[\.\):]?\s*(.*)$',
+    re.IGNORECASE,
+)
+
+# Catches numbering that does NOT cleanly match the X.Y pattern above
+# (e.g. "2.3.1", "2.3a", "2-3"), so it can be preserved without being
+# discarded or merged into a neighbouring clause.
+AMBIGUOUS_HEADER_PATTERN = re.compile(
+    r'^(?:Clause\s+|Section\s+)?(\d+(?:[\.\-]\d+){1,}[a-zA-Z]?|\d+[a-zA-Z])'
+    r'[\.\):]?\s+(.+)$',
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Skill: retrieve_policy
+# ---------------------------------------------------------------------------
+
+def retrieve_policy(input_path):
+    """
+    Skill: retrieve_policy
+
+    Loads the .txt policy file at `input_path` and returns its content
+    as structured numbered sections.
+
+    Returns a dict:
+        {
+            "sections": {clause_id: clause_text, ...},
+            "ambiguous": {best_guess_id: raw_text, ...},
+            "preamble": "<any text before the first recognised clause>",
+        }
+
+    error_handling (skills.md):
+      - Missing / non-.txt input -> raises FileNotFoundError / ValueError,
+        caller must not proceed to summarize_policy.
+      - Empty file or no identifiable numbered clauses -> raises ValueError.
+      - Malformed/ambiguous clause numbering -> preserved under a
+        best-guess identifier in "ambiguous", never discarded or merged.
+      - The source text is never altered, paraphrased, or omitted during
+        retrieval; this is a structural mapping only.
+    """
+    # error_handling: input file existence / type check
+    if not os.path.isfile(input_path):
+        raise FileNotFoundError(
+            f"retrieve_policy error: input file not found: {input_path}"
+        )
+    if not input_path.lower().endswith(".txt"):
+        raise ValueError(
+            f"retrieve_policy error: input file is not a .txt file: "
+            f"{input_path}"
+        )
+
+    with open(input_path, "r", encoding="utf-8") as f:
+        raw_text = f.read()
+
+    # error_handling: empty file
+    if not raw_text.strip():
+        raise ValueError(
+            "retrieve_policy error: input file is empty; no sections "
+            "could be extracted."
+        )
+
+    sections = {}
+    ambiguous = {}
+    preamble_lines = []
+
+    current_clause = None
+    current_lines = []
+    ambiguous_counter = 0
+
+    def flush_current():
+        if current_clause is not None:
+            text = "\n".join(current_lines).strip()
+            if current_clause in sections:
+                # Same clause id seen twice in the source: append rather
+                # than overwrite, so nothing is lost or merged silently
+                # into an unrelated clause.
+                sections[current_clause] = (
+                    sections[current_clause] + "\n" + text
+                ).strip()
+            else:
+                sections[current_clause] = text
+
+    for raw_line in raw_text.splitlines():
+        line = raw_line.strip()
+
+        if not line:
+            if current_clause is not None:
+                current_lines.append("")
+            continue
+
+        clean_match = CLAUSE_HEADER_PATTERN.match(line)
+        if clean_match:
+            flush_current()
+            current_clause = clean_match.group(1)
+            remainder = clean_match.group(2).strip()
+            current_lines = [remainder] if remainder else []
+            continue
+
+        ambig_match = AMBIGUOUS_HEADER_PATTERN.match(line)
+        if ambig_match:
+            # error_handling: malformed/ambiguous numbering -> preserve
+            # raw text under a best-guess identifier, flagged separately.
+            flush_current()
+            current_clause = None
+            current_lines = []
+            ambiguous_counter += 1
+            best_guess_id = ambig_match.group(1)
+            ambiguous[best_guess_id] = line
+            continue
+
+        if current_clause is not None:
+            current_lines.append(line)
+        else:
+            preamble_lines.append(line)
+
+    flush_current()
+
+    # error_handling: no identifiable numbered clauses at all
+    if not sections:
+        raise ValueError(
+            "retrieve_policy error: no identifiable numbered clauses "
+            "were found in the input file; cannot produce structured "
+            "sections."
+        )
+
+    return {
+        "sections": sections,
+        "ambiguous": ambiguous,
+        "preamble": "\n".join(preamble_lines).strip(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Skill: summarize_policy
+# ---------------------------------------------------------------------------
+
+def normalize_whitespace(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def split_sentences(text):
+    """Lightweight sentence splitter, sufficient for policy clause text."""
+    parts = re.split(r"(?<=[.;])\s+", text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def compress_clause(clause_id, text):
+    """
+    Attempt a conservative compression of a clause: keep only sentences
+    that carry a required binding verb / multi-condition term, or that
+    contain a number (dates, day counts, hour limits, approver names,
+    etc. tend to anchor the obligation). Always keep at least the first
+    sentence.
+    """
+    sentences = split_sentences(text)
+    if len(sentences) <= 1:
+        return text
+
+    required_terms = []
+    required_terms.extend(BINDING_VERBS.get(clause_id, []))
+    required_terms.extend(MULTI_CONDITION_TERMS.get(clause_id, []))
+
+    kept = []
+    for sentence in sentences:
+        lowered = sentence.lower()
+        has_required_term = any(
+            term.lower() in lowered for term in required_terms
+        )
+        has_number = bool(re.search(r"\d", sentence))
+        if has_required_term or has_number or not kept:
+            kept.append(sentence)
+
+    return " ".join(kept)
+
+
+def has_scope_bleed(text):
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in SCOPE_BLEED_PHRASES)
+
+
+def strip_scope_bleed(text):
+    cleaned = text
+    for phrase in SCOPE_BLEED_PHRASES:
+        cleaned = re.sub(re.escape(phrase), "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r" {2,}", " ", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned
+
+
+def verify_clause(clause_id, text):
+    """
+    Verification gate used before any compressed clause is allowed into
+    the summary.
+
+    Enforces:
+      - Enforcement rule 4 / obligation softening: required binding-verb
+        keyword(s) for this clause must still be present.
+      - Enforcement rule 2: ALL multi-condition terms for this clause
+        (e.g. clause 5.2's two approvers) must still be present.
+      - Enforcement rule 3 / context: no scope-bleed phrasing.
+    """
+    lowered = text.lower()
+
+    for verb in BINDING_VERBS.get(clause_id, []):
+        if verb.lower() not in lowered:
+            return False
+
+    for term in MULTI_CONDITION_TERMS.get(clause_id, []):
+        if term.lower() not in lowered:
+            return False
+
+    if has_scope_bleed(text):
+        return False
+
+    return True
+
+
+def build_clause_entry(clause_id, clause_text):
+    """
+    Produce one "Clause X.Y: ..." line for the summary.
+
+    If a verified compression is possible, use it. Otherwise (per
+    enforcement rule 4 and the summarize_policy error_handling table),
+    fall back to the verbatim source text, explicitly flagged as
+    [VERBATIM].
+    """
+    normalized = normalize_whitespace(clause_text)
+
+    candidate = normalize_whitespace(compress_clause(clause_id, normalized))
+
+    if verify_clause(clause_id, candidate):
+        return f"Clause {clause_id}: {candidate}"
+
+    # error_handling: cannot condense without meaning loss -> verbatim,
+    # explicitly flagged.
+    return f"Clause {clause_id}: [VERBATIM] {normalized}"
+
+
+def summarize_policy(retrieved):
+    """
+    Skill: summarize_policy
+
+    Takes the structure returned by retrieve_policy and produces a
+    compliant, clause-referenced plain-text summary.
+
+    error_handling (skills.md):
+      - Empty/malformed input -> raises ValueError; caller must run
+        retrieve_policy successfully first.
+      - Missing required clauses -> raises ValueError rather than
+        emitting an incomplete summary (clause-omission guard).
+      - Multi-condition / binding-verb integrity and scope-bleed
+        avoidance are enforced per-clause via verify_clause(), with a
+        verbatim fallback when compression cannot be verified safe.
+    """
+    if not retrieved or not retrieved.get("sections"):
+        raise ValueError(
+            "summarize_policy error: input structured sections are empty "
+            "or malformed; retrieve_policy must be run successfully "
+            "before summarize_policy."
+        )
+
+    sections = retrieved["sections"]
+    ambiguous = retrieved.get("ambiguous", {})
+
+    # Enforcement rule 1: every clause in the required inventory must be
+    # present. If any is missing, do not emit an incomplete summary.
+    missing = [c for c in REQUIRED_CLAUSES if c not in sections]
+    if missing:
+        raise ValueError(
+            "summarize_policy error: the following required clauses are "
+            f"missing from the retrieved sections and cannot be "
+            f"summarised: {', '.join(missing)}"
+        )
+
+    def clause_sort_key(clause_id):
+        try:
+            return tuple(int(p) for p in clause_id.split("."))
+        except ValueError:
+            return (float("inf"),)
+
+    lines = []
+    lines.append("HR LEAVE POLICY SUMMARY")
+    lines.append("=" * 40)
+    lines.append("")
+    lines.append(
+        "This summary preserves the clause numbering, the core "
+        "obligation, the binding-verb strength, and all multi-part "
+        "conditions of the source policy document. No information "
+        "beyond the source document has been added. Where a clause "
+        "could not be condensed without risking a change in meaning, "
+        "it is reproduced verbatim and marked [VERBATIM]."
+    )
+    lines.append("")
+
+    for clause_id in sorted(sections.keys(), key=clause_sort_key):
+        clause_text = sections[clause_id]
+        if not clause_text.strip():
+            # Nothing to summarise, but the clause reference must still
+            # appear so it is not silently dropped.
+            lines.append(
+                f"Clause {clause_id}: [VERBATIM] "
+                f"(no content was found under this clause heading)"
+            )
+            lines.append("")
+            continue
+
+        lines.append(build_clause_entry(clause_id, clause_text))
+        lines.append("")
+
+    if ambiguous:
+        lines.append("AMBIGUOUS / UNPARSED CONTENT")
+        lines.append("-" * 40)
+        lines.append(
+            "The following lines did not match the expected clause "
+            "numbering and are reproduced verbatim rather than "
+            "discarded or merged into another clause:"
+        )
+        lines.append("")
+        for best_guess_id, raw_text in ambiguous.items():
+            lines.append(f"[AMBIGUOUS {best_guess_id}] [VERBATIM] {raw_text}")
+        lines.append("")
+
+    summary_text = "\n".join(lines).rstrip() + "\n"
+
+    # Final defensive pass: scope-bleed phrases must never appear in the
+    # output, even if introduced by a bug in compression logic above.
+    summary_text = strip_scope_bleed(summary_text)
+
+    return summary_text
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(
+        description=(
+            "UC-0B: HR Leave Policy summarization agent. Reads a policy "
+            ".txt file, structures it into numbered clauses "
+            "(retrieve_policy), and writes a compliant clause-referenced "
+            "summary (summarize_policy)."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help=(
+            "Path to the input policy .txt file, e.g. "
+            "../data/policy-documents/policy_hr_leave.txt"
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write the summary output file, e.g. "
+             "summary_hr_leave.txt",
+    )
+    args = parser.parse_args()
+
+    # Step 1: retrieve_policy (must succeed before summarize_policy runs)
+    try:
+        retrieved = retrieve_policy(args.input)
+    except (FileNotFoundError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
+    # Step 2: summarize_policy
+    try:
+        summary_text = summarize_policy(retrieved)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
+    # Step 3: write output to the path specified by --output
+    output_path = args.output
+    output_dir = os.path.dirname(output_path)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(summary_text)
+
+    print(f"Summary written to: {output_path}")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,30 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
-
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Loads the .txt policy file from the input path and returns its content as structured numbered sections corresponding to each clause.
+    input:
+      type: string
+      format: File path to a .txt policy document (e.g. ../data/policy-documents/policy_hr_leave.txt)
+    output:
+      type: object
+      format: A structured mapping of clause numbers (e.g. "2.3", "2.4", "5.2") to their corresponding section text, preserving original wording and ordering as found in the source document
+    error_handling:
+      - If the file path does not exist or is not a .txt file, return an error indicating the input file could not be found or read, and do not proceed to summarize_policy.
+      - If the file is empty or contains no identifiable numbered clauses, return an error indicating no structured sections could be extracted, rather than returning an empty or fabricated structure.
+      - If a clause appears malformed or its numbering is ambiguous, preserve the raw text under a best-guess clause identifier and flag it as ambiguous rather than discarding or merging it with another clause.
+      - Never alter, paraphrase, or omit any portion of the source text during retrieval; retrieval must be a faithful structural mapping only.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Takes structured numbered sections from retrieve_policy and produces a compliant summary with clause references that preserves every clause, all multi-condition obligations, and original binding-verb strength.
+    input:
+      type: object
+      format: A structured mapping of clause numbers (e.g. "2.3", "2.4", "5.2") to their corresponding section text, as returned by retrieve_policy
+    output:
+      type: string
+      format: Plain text summary written to uc-0b/summary_hr_leave.txt, organized by clause number, with each clause's obligation and binding verb strength preserved, and any verbatim-quoted clauses explicitly flagged
+    error_handling:
+      - If any clause from the input structured sections is missing from the generated summary, regenerate the summary to include the missing clause rather than emitting an incomplete output (addresses clause omission failure mode).
+      - If a multi-condition obligation (e.g. clause 5.2's requirement for both Department Head AND HR Director approval) would have any condition dropped, retain all conditions explicitly rather than collapsing them into a single generic condition (addresses condition-drop failure mode).
+      - If a binding verb would be softened (e.g. "requires" or "must" rendered as "should" or "is encouraged"), correct it to match the original binding strength from the source clause (addresses obligation softening failure mode).
+      - If the summarization process would introduce content not present in the source sections (e.g. phrases like "as is standard practice" or "typically in government organisations"), remove such content before output (addresses scope bleed failure mode).
+      - If a clause cannot be condensed without meaning loss, output that clause's text verbatim and prepend a flag (e.g. "[VERBATIM]") indicating it was quoted rather than summarized.
+      - If the input structured sections are empty or malformed, do not produce a summary; return an error indicating retrieve_policy must be run successfully first.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,62 @@
+HR LEAVE POLICY SUMMARY
+========================================
+
+This summary preserves the clause numbering, the core obligation, the binding-verb strength, and all multi-part conditions of the source policy document. No information beyond the source document has been added. Where a clause could not be condensed without risking a change in meaning, it is reproduced verbatim and marked [VERBATIM].
+
+Clause 1.1: This policy governs all leave entitlements for permanent and contractual employees of the City Municipal Corporation (CMC).
+
+Clause 1.2: This policy does not apply to daily wage workers or consultants. ═══════════════════════════════════════════════════════════ 2.
+
+Clause 2.1: Each permanent employee is entitled to 18 days of paid annual leave per calendar year.
+
+Clause 2.2: Annual leave accrues at 1.5 days per month from the date of joining.
+
+Clause 2.3: Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+
+Clause 2.4: Leave applications must receive written approval from the employee's direct manager before the leave commences.
+
+Clause 2.5: Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.
+
+Clause 2.6: Employees may carry forward a maximum of 5 unused annual leave days to the following calendar year. Any days above 5 are forfeited on 31 December.
+
+Clause 2.7: Carry-forward days must be used within the first quarter (January–March) of the following year or they are forfeited. ═══════════════════════════════════════════════════════════ 3.
+
+Clause 3.1: Each employee is entitled to 12 days of paid sick leave per calendar year.
+
+Clause 3.2: Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.
+
+Clause 3.3: Sick leave cannot be carried forward to the following year.
+
+Clause 3.4: Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration. ═══════════════════════════════════════════════════════════ 4.
+
+Clause 4.1: Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
+
+Clause 4.2: For a third or subsequent child, maternity leave is 12 weeks paid.
+
+Clause 4.3: Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+
+Clause 4.4: Paternity leave cannot be split across multiple periods. ═══════════════════════════════════════════════════════════ 5.
+
+Clause 5.1: An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.
+
+Clause 5.2: LWP requires approval from the Department Head and the HR Director.
+
+Clause 5.3: LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.
+
+Clause 5.4: Periods of LWP do not count toward service for the purposes of seniority, increments, or retirement benefits. ═══════════════════════════════════════════════════════════ 6.
+
+Clause 6.1: Employees are entitled to all gazetted public holidays as declared by the State Government each year.
+
+Clause 6.2: If an employee is required to work on a public holiday, they are entitled to one compensatory off day, to be taken within 60 days of the holiday worked.
+
+Clause 6.3: Compensatory off cannot be encashed. ═══════════════════════════════════════════════════════════ 7.
+
+Clause 7.1: Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.
+
+Clause 7.2: Leave encashment during service is not permitted under any circumstances.
+
+Clause 7.3: Sick leave and LWP cannot be encashed under any circumstances. ═══════════════════════════════════════════════════════════ 8.
+
+Clause 8.1: Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+
+Clause 8.2: Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.


### PR DESCRIPTION
HR Leave Policy Summary Agent

Populate UC-0B with a complete HR leave policy summarize: implement retrieve_policy and summarize_policy skills in uc-0b/app.py (clause parsing, conservative compression, verification of binding verbs and multi-condition terms, scope-bleed removal), add CLI (--input/--output) and robust error handling. Update uc-0b/agents.md to specify agent role, intent, context and enforcement rules (clause inventory, verb-strength preservation, refusal conditions). Update uc-0b/skills.md to document retrieve_policy and summarize_policy inputs, outputs and error-handling. Add generated example output uc-0b/summary_hr_leave.txt demonstrating the expected clause-referenced summary format.