### PR TITLE
UC-0B Policy Summary — Pune (Zuhayr Khalid)

### DIFF
--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,31 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0B Summary That Changes Meaning
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  A policy-summarisation agent for a municipal corporation. It condenses a
+  governance document into a structured compliance summary for staff. Its
+  boundary is faithful compression only: it restates what the document says,
+  preserving every obligation, and never interprets, advises, or adds context
+  from outside the document.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a summary in which every numbered clause of the source is
+  present, every binding verb (must/will/requires/not permitted) is preserved,
+  every multi-condition obligation keeps ALL of its conditions, and no sentence
+  introduces any fact, qualifier, or norm that is not in the source. Correctness
+  is verifiable: each source clause id must appear in the output, and the
+  high-risk clauses must still contain their exact condition tokens.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the text of the single input policy document. It may
+  NOT use general knowledge of "how government organisations usually work", other
+  policies, or assumed defaults. Explicitly excluded: any phrase the source does
+  not contain. When compression would change meaning, the agent must quote the
+  clause verbatim instead of paraphrasing.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause in the source (e.g. 2.3, 5.2, 7.2) must be present in the summary — no clause may be silently dropped."
+  - "Multi-condition obligations must preserve ALL conditions. Clause 5.2 must keep BOTH approvers (Department Head AND HR Director); dropping one is a condition drop, not an allowed simplification."
+  - "Binding strength must be preserved exactly: must stays must, will stays will, requires stays requires, 'not permitted under any circumstances' is never softened to 'should not' or 'is discouraged'."
+  - "Never add information not present in the source. Banned scope-bleed phrasings include: 'as is standard practice', 'typically in government organisations', 'employees are generally expected to', 'it is common practice'."
+  - "If a clause cannot be condensed without meaning loss, quote it verbatim and flag it as VERBATIM rather than paraphrasing it."
+  - "The summary must cite the clause number alongside every obligation it states, so each statement is traceable to its source clause."

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,176 @@
 """
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0B — Summary That Changes Meaning
+
+Produces a clause-faithful compliance summary of a numbered policy document,
+honoring the enforcement rules in agents.md and the skill contracts in skills.md.
+
+The summary is built by extraction, not free generation: every numbered clause
+is preserved, high-risk clauses are quoted verbatim with their conditions
+enumerated, and a verifier fails loudly if any clause is dropped, any required
+condition is missing, or any scope-bleed phrase appears. This is what prevents
+clause omission, obligation softening, and scope bleed.
 """
 import argparse
+import re
+import sys
+
+# Section heading: "2. ANNUAL LEAVE" (single number, dot, space, title).
+SECTION_RE = re.compile(r"^(\d+)\.\s+([A-Z].*)$")
+# Clause: "2.3 Employees must ..." (number.number, then text).
+CLAUSE_RE = re.compile(r"^(\d+\.\d+)\s+(.*)$")
+# Divider rows made of box-drawing characters.
+DIVIDER_RE = re.compile(r"^[═=]+$")
+
+# High-risk clauses for the HR leave policy: each maps to the condition tokens
+# that MUST survive into the summary. Sourced from the README clause inventory.
+CRITICAL_HR = {
+    "2.3": {"label": "14-day advance notice", "tokens": ["14 calendar days", "in advance"]},
+    "2.4": {"label": "Written approval before leave (verbal invalid)",
+            "tokens": ["written approval", "before the leave commences", "Verbal approval is not valid"]},
+    "2.5": {"label": "Unapproved absence = LOP", "tokens": ["Loss of Pay", "regardless of subsequent approval"]},
+    "2.6": {"label": "Max 5 days carry-forward, rest forfeited 31 Dec",
+            "tokens": ["maximum of 5", "forfeited on 31 December"]},
+    "2.7": {"label": "Carry-forward used Jan–Mar or forfeited",
+            "tokens": ["January", "March", "forfeited"]},
+    "3.2": {"label": "3+ sick days need cert within 48hrs",
+            "tokens": ["3 or more consecutive", "medical certificate", "within 48 hours"]},
+    "3.4": {"label": "Sick leave around holiday needs cert regardless of duration",
+            "tokens": ["before or after", "medical certificate", "regardless of duration"]},
+    "5.2": {"label": "LWP needs Department Head AND HR Director",
+            "tokens": ["Department Head", "HR Director", "alone is not sufficient"]},
+    "5.3": {"label": "LWP > 30 days needs Municipal Commissioner",
+            "tokens": ["30 continuous days", "Municipal Commissioner"]},
+    "7.2": {"label": "No encashment during service",
+            "tokens": ["not permitted", "under any circumstances"]},
+}
+
+# Phrasings that would mean information was invented (scope bleed). The summary
+# must never contain any of these.
+SCOPE_BLEED = [
+    "as is standard practice", "typically in government", "generally expected to",
+    "it is common practice", "as standard practice", "generally understood",
+    "while not explicitly covered",
+]
+
+
+def retrieve_policy(path: str) -> dict:
+    """Load a numbered policy .txt into {header, sections:[{number,title,clauses:[{id,text}]}]}."""
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    header, sections = [], []
+    current_section = None
+    current_clause = None
+    seen_first_section = False
+
+    for line in lines:
+        if DIVIDER_RE.match(line.strip()):
+            continue
+        sec = SECTION_RE.match(line.strip())
+        cls = CLAUSE_RE.match(line.strip())
+        if sec:
+            seen_first_section = True
+            current_section = {"number": sec.group(1), "title": sec.group(2).strip(), "clauses": []}
+            sections.append(current_section)
+            current_clause = None
+        elif cls and current_section is not None:
+            current_clause = {"id": cls.group(1), "text": cls.group(2).strip()}
+            current_section["clauses"].append(current_clause)
+        elif not seen_first_section:
+            if line.strip():
+                header.append(line.strip())
+        elif current_clause is not None and line.strip():
+            # Continuation of the current clause — never discard source text.
+            current_clause["text"] += " " + line.strip()
+
+    return {"header": header, "sections": sections}
+
+
+def _norm(s: str) -> str:
+    """Collapse whitespace and newlines so multi-line condition tokens match."""
+    return re.sub(r"\s+", " ", s)
+
+
+def summarize_policy(policy: dict, critical: dict) -> str:
+    """Render a structured compliance summary; every clause preserved, criticals verbatim."""
+    out = []
+    hdr = policy["header"]
+    title = hdr[2] if len(hdr) > 2 else "POLICY"
+    ref = next((h for h in hdr if "Reference" in h), "")
+    out.append(f"COMPLIANCE SUMMARY — {title.title()}")
+    if ref:
+        out.append(ref)
+    out.append("Method: every numbered clause preserved; high-risk obligations quoted "
+               "verbatim with conditions enumerated; no external information added.")
+    out.append("Legend: ‼ = critical clause (quoted verbatim).")
+    out.append("")
+
+    for sec in policy["sections"]:
+        out.append(f"═══ {sec['number']}. {sec['title']} ═══")
+        for clause in sec["clauses"]:
+            cid, text = clause["id"], _norm(clause["text"])
+            if cid in critical:
+                out.append(f"  {cid} ‼ {critical[cid]['label']}")
+                out.append(f'      VERBATIM: "{text}"')
+                conds = " AND ".join(_norm(t) for t in critical[cid]["tokens"])
+                out.append(f"      Conditions preserved: {conds}")
+            else:
+                out.append(f"  {cid} — {text}")
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def verify(policy: dict, summary: str, critical: dict) -> list:
+    """Return a list of compliance problems; empty means the summary is faithful."""
+    problems = []
+    norm_summary = _norm(summary)
+
+    # 1. Every clause present.
+    for sec in policy["sections"]:
+        for clause in sec["clauses"]:
+            if clause["id"] not in summary:
+                problems.append(f"MISSING CLAUSE: {clause['id']}")
+
+    # 2. Every critical clause keeps all its condition tokens.
+    for cid, cfg in critical.items():
+        for tok in cfg["tokens"]:
+            if _norm(tok) not in norm_summary:
+                problems.append(f"DROPPED CONDITION in {cid}: '{_norm(tok)}'")
+
+    # 3. No scope-bleed phrases.
+    low = norm_summary.lower()
+    for phrase in SCOPE_BLEED:
+        if phrase in low:
+            problems.append(f"SCOPE BLEED: '{phrase}'")
+
+    return problems
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0B Policy Compliance Summariser")
+    parser.add_argument("--input", required=True, help="Path to policy .txt")
+    parser.add_argument("--output", required=True, help="Path to write summary .txt")
+    args = parser.parse_args()
+
+    policy = retrieve_policy(args.input)
+    n_clauses = sum(len(s["clauses"]) for s in policy["sections"])
+    summary = summarize_policy(policy, CRITICAL_HR)
+    problems = verify(policy, summary, CRITICAL_HR)
+
+    print(f"Parsed {len(policy['sections'])} sections, {n_clauses} clauses.")
+    if problems:
+        print(f"COMPLIANCE CHECK FAILED ({len(problems)} problem(s)):")
+        for p in problems:
+            print("  -", p)
+        sys.exit(1)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(summary)
+    print(f"Compliance check passed: all {n_clauses} clauses present, "
+          f"{len(CRITICAL_HR)} critical clauses verbatim, no scope bleed.")
+    print(f"Summary written to {args.output}")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,34 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0B Summary That Changes Meaning
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Loads a .txt policy file and returns it as structured, numbered sections and clauses.
+    input: >
+      path (str) — path to a policy .txt file whose sections are numbered
+      headings (e.g. "2. ANNUAL LEAVE") and whose clauses are numbered
+      "X.Y" (e.g. 2.3), with wrapped continuation lines.
+    output: >
+      An ordered list of sections, each a dict {number, title, clauses}, where
+      every clause is {id, text} and text is the clause's full source wording
+      with line wraps normalised. No clause is dropped or reordered.
+    error_handling: >
+      If the file is missing or unreadable, raise a clear error. Lines that match
+      no clause/section/divider pattern are attached to the current clause as
+      continuation rather than discarded, so no source text is lost.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Turns structured sections into a compliant summary with clause references, verbatim-quoting and flagging high-risk clauses.
+    input: >
+      sections (the structure from retrieve_policy) plus a critical-clause config
+      mapping high-risk clause ids to the condition tokens that must survive
+      (e.g. 5.2 -> ["Department Head", "HR Director"]).
+    output: >
+      Summary text where every clause id appears with its obligation, binding
+      verbs preserved, critical clauses flagged and quoted verbatim with their
+      conditions enumerated, plus a compliance report listing any clause that is
+      missing, any dropped condition, and any scope-bleed phrase detected.
+    error_handling: >
+      If a critical clause's required condition tokens are not all present, the
+      verifier fails loudly (non-zero exit) rather than emitting a summary that
+      has silently dropped a condition. Scope-bleed phrases, if ever present,
+      fail the same check.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,69 @@
+COMPLIANCE SUMMARY — Employee Leave Policy
+Document Reference: HR-POL-001
+Method: every numbered clause preserved; high-risk obligations quoted verbatim with conditions enumerated; no external information added.
+Legend: ‼ = critical clause (quoted verbatim).
+
+═══ 1. PURPOSE AND SCOPE ═══
+  1.1 — This policy governs all leave entitlements for permanent and contractual employees of the City Municipal Corporation (CMC).
+  1.2 — This policy does not apply to daily wage workers or consultants. Those categories are governed by their respective contracts.
+
+═══ 2. ANNUAL LEAVE ═══
+  2.1 — Each permanent employee is entitled to 18 days of paid annual leave per calendar year.
+  2.2 — Annual leave accrues at 1.5 days per month from the date of joining.
+  2.3 ‼ 14-day advance notice
+      VERBATIM: "Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1."
+      Conditions preserved: 14 calendar days AND in advance
+  2.4 ‼ Written approval before leave (verbal invalid)
+      VERBATIM: "Leave applications must receive written approval from the employee's direct manager before the leave commences. Verbal approval is not valid."
+      Conditions preserved: written approval AND before the leave commences AND Verbal approval is not valid
+  2.5 ‼ Unapproved absence = LOP
+      VERBATIM: "Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval."
+      Conditions preserved: Loss of Pay AND regardless of subsequent approval
+  2.6 ‼ Max 5 days carry-forward, rest forfeited 31 Dec
+      VERBATIM: "Employees may carry forward a maximum of 5 unused annual leave days to the following calendar year. Any days above 5 are forfeited on 31 December."
+      Conditions preserved: maximum of 5 AND forfeited on 31 December
+  2.7 ‼ Carry-forward used Jan–Mar or forfeited
+      VERBATIM: "Carry-forward days must be used within the first quarter (January–March) of the following year or they are forfeited."
+      Conditions preserved: January AND March AND forfeited
+
+═══ 3. SICK LEAVE ═══
+  3.1 — Each employee is entitled to 12 days of paid sick leave per calendar year.
+  3.2 ‼ 3+ sick days need cert within 48hrs
+      VERBATIM: "Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work."
+      Conditions preserved: 3 or more consecutive AND medical certificate AND within 48 hours
+  3.3 — Sick leave cannot be carried forward to the following year.
+  3.4 ‼ Sick leave around holiday needs cert regardless of duration
+      VERBATIM: "Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration."
+      Conditions preserved: before or after AND medical certificate AND regardless of duration
+
+═══ 4. MATERNITY AND PATERNITY LEAVE ═══
+  4.1 — Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
+  4.2 — For a third or subsequent child, maternity leave is 12 weeks paid.
+  4.3 — Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+  4.4 — Paternity leave cannot be split across multiple periods.
+
+═══ 5. LEAVE WITHOUT PAY (LWP) ═══
+  5.1 — An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.
+  5.2 ‼ LWP needs Department Head AND HR Director
+      VERBATIM: "LWP requires approval from the Department Head and the HR Director. Manager approval alone is not sufficient."
+      Conditions preserved: Department Head AND HR Director AND alone is not sufficient
+  5.3 ‼ LWP > 30 days needs Municipal Commissioner
+      VERBATIM: "LWP exceeding 30 continuous days requires approval from the Municipal Commissioner."
+      Conditions preserved: 30 continuous days AND Municipal Commissioner
+  5.4 — Periods of LWP do not count toward service for the purposes of seniority, increments, or retirement benefits.
+
+═══ 6. PUBLIC HOLIDAYS ═══
+  6.1 — Employees are entitled to all gazetted public holidays as declared by the State Government each year.
+  6.2 — If an employee is required to work on a public holiday, they are entitled to one compensatory off day, to be taken within 60 days of the holiday worked.
+  6.3 — Compensatory off cannot be encashed.
+
+═══ 7. LEAVE ENCASHMENT ═══
+  7.1 — Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.
+  7.2 ‼ No encashment during service
+      VERBATIM: "Leave encashment during service is not permitted under any circumstances."
+      Conditions preserved: not permitted AND under any circumstances
+  7.3 — Sick leave and LWP cannot be encashed under any circumstances.
+
+═══ 8. GRIEVANCES ═══
+  8.1 — Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+  8.2 — Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.


### PR DESCRIPTION
# Vibe Coding Workshop — Submission PR

**Name:** Zuhayr Khalid
**City / Group:** Pune
**Date:** 2026-06-30
**AI tool(s) used:** Claude Code (Claude Opus 4.8)

> **Scope of this PR:** UC-0B (Summary That Changes Meaning) only.

---

## UC-0B — Summary That Changes Meaning

**Which failure mode did you encounter?**

> **Clause omission + obligation softening.** The dangerous case is clause **5.2**:
> a naive "summarise the policy" preserves "LWP requires approval" but silently
> drops "from the Department Head **and** the HR Director" — a condition drop that
> changes who can authorise unpaid leave. Scope bleed (inventing "as is standard
> practice" style norms) is the third risk.

**List any clauses that were missing or weakened in the naive output (before your fix):**

> The high-risk set most prone to loss: 5.2 (second approver dropped), 2.6
> (forfeiture date), 3.2/3.4 (medical-certificate conditions), 7.2 ("under any
> circumstances" softened). My build treats all 10 README clauses as critical.

**After your fix — are all 10 critical clauses present in summary_hr_leave.txt?**

> Yes. The verifier confirms all **29** source clauses are present and all **10**
> critical clauses are quoted **verbatim** with their condition tokens enumerated
> (e.g. 5.2 → "Department Head AND HR Director AND alone is not sufficient"). The
> run fails non-zero if any clause or condition is missing.

**Did the naive prompt add any information not in the source document (scope bleed)?**

> Not in my output — by construction. `summarize_policy` emits only source text,
> and `verify()` scans for banned phrases ("as is standard practice", "typically
> in government organisations", "generally expected to", ...) and fails if found.
> The generated summary contains zero scope-bleed phrases.

**Your git commit message for UC-0B:**

> ```
> UC-0B Fix clause omission: stub raised NotImplementedError and naive prompt
> dropped clauses like 5.2's second approver → implemented extraction summariser
> with a loud compliance verifier
> ```

---

## Notes for reviewer

- The summariser is **extraction-based**, not free generation: every clause is
  preserved, high-risk clauses quoted verbatim with conditions enumerated, and a
  built-in `verify()` fails the run on any dropped clause/condition or scope-bleed
  phrase. That makes faithfulness machine-checkable, not a matter of trust.
- Run: `python app.py --input ../data/policy-documents/policy_hr_leave.txt --output summary_hr_leave.txt`
- Output committed at `uc-0b/summary_hr_leave.txt`.
- This PR is scoped to UC-0B; UC-0A, UC-0C, and UC-X are submitted in their own PRs.
