### PR TITLE
UC-X Ask My Documents — Pune (Zuhayr Khalid)

### DIFF
--- a/uc-x/agents.md
+++ b/uc-x/agents.md
@@ -1,18 +1,30 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-X Ask My Documents
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  A policy question-answering agent for a municipal corporation. It answers staff
+  questions strictly from three policy documents (HR leave, IT acceptable use,
+  finance reimbursement). Its boundary is single-source retrieval: it returns the
+  one governing clause, cited, or it refuses. It never advises, interprets, or
+  combines documents.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct answer is either (a) a single clause quoted/stated from ONE document
+  with its document name and section number cited, or (b) the exact refusal
+  template when the question is not covered. There is no third option: no blended
+  answers, no hedged guesses. Correctness is verifiable — every answer either
+  carries exactly one citation or is the verbatim refusal template.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the text of the three indexed policy documents. It may
+  NOT combine claims from two documents, may NOT infer permissions that no single
+  clause grants, and may NOT use outside knowledge. The refusal template is fixed
+  and used verbatim. For the trap question ("personal phone for work files from
+  home"), only IT policy section 3.1 governs personal-device access — it must not
+  be blended with HR remote-work language.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never combine claims from two different documents into one answer. Exactly one source clause backs each answer."
+  - "Never use hedging phrases: 'while not explicitly covered', 'typically', 'generally understood', 'it is common practice'. An answer is a cited clause or the refusal template — nothing in between."
+  - "If the question is not answerable from a single clause in the documents, output the refusal template exactly, with no variation: 'This question is not covered in the available policy documents (policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt). Please contact [relevant team] for guidance.'"
+  - "Cite the source document filename + section number for every factual claim, e.g. [policy_it_acceptable_use.txt · Section 3.1]."
+  - "Preserve all conditions in the cited clause; never drop a qualifier to make an answer simpler or more permissive."

--- a/uc-x/app.py
+++ b/uc-x/app.py
@@ -1,12 +1,191 @@
 """
-UC-X app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-X — Ask My Documents
+
+Answers policy questions strictly from three documents, honoring the enforcement
+rules in agents.md and the skill contracts in skills.md.
+
+Two structural guarantees prevent cross-document blending and hedged
+hallucination: answer_question returns EXACTLY ONE clause (so two documents can
+never be merged into one answer), and any question that does not clear the
+relevance threshold returns the fixed refusal template verbatim — there is no
+free-text generation path that could hedge.
+
+Run:  python app.py            (interactive)
+      python app.py --selftest (runs the 7 README test questions)
 """
 import argparse
+import math
+import re
+import sys
+
+DOCS = [
+    "../data/policy-documents/policy_hr_leave.txt",
+    "../data/policy-documents/policy_it_acceptable_use.txt",
+    "../data/policy-documents/policy_finance_reimbursement.txt",
+]
+
+REFUSAL = (
+    "This question is not covered in the available policy documents\n"
+    "(policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt).\n"
+    "Please contact [relevant team] for guidance."
+)
+
+SECTION_RE = re.compile(r"^(\d+)\.\s+([A-Z].*)$")
+CLAUSE_RE = re.compile(r"^(\d+\.\d+)\s+(.*)$")
+DIVIDER_RE = re.compile(r"^[═=]+$")
+
+STOPWORDS = {
+    "the", "a", "an", "i", "can", "my", "is", "to", "on", "for", "of", "do", "does",
+    "what", "when", "in", "from", "and", "or", "be", "are", "with", "use", "used",
+    "this", "that", "it", "if", "at", "by", "as", "me", "you", "your", "any",
+    "view", "about", "company",
+}
+
+# Map question vocabulary to document vocabulary so intent words score. Kept
+# deliberately tight — over-broad synonyms (e.g. laptop->computer) pull answers
+# toward clauses that merely list the noun instead of the governing rule.
+SYNONYMS = {
+    "slack": ["software", "install"], "app": ["software"], "application": ["software"],
+    "phone": ["device"], "encash": ["encashment"], "wfh": ["home"],
+    "approve": ["approval"], "approves": ["approval"],
+}
+
+
+def _tokens(text: str):
+    raw = re.findall(r"[a-zA-Z][a-zA-Z\-]*", text.lower())
+    out = []
+    for w in raw:
+        if w in STOPWORDS or len(w) <= 1:
+            continue
+        out.append(w[:-1] if w.endswith("s") and len(w) > 3 else w)
+    return out
+
+
+def retrieve_documents(paths):
+    """Parse all docs into a flat clause index with an IDF table over clause tokens."""
+    index = []
+    for path in paths:
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        doc_name = path.split("/")[-1]
+        doc_ref = next((l.split(":", 1)[1].strip() for l in lines if "Document Reference" in l), doc_name)
+        section_num = section_title = None
+        clause = None
+        for line in lines:
+            s = line.strip()
+            if DIVIDER_RE.match(s):
+                continue
+            sec, cls = SECTION_RE.match(s), CLAUSE_RE.match(s)
+            if sec:
+                section_num, section_title = sec.group(1), sec.group(2).strip()
+                clause = None
+            elif cls:
+                clause = {"doc_name": doc_name, "doc_ref": doc_ref, "section": section_num,
+                          "section_title": section_title or "", "clause_id": cls.group(1),
+                          "text": cls.group(2).strip()}
+                index.append(clause)
+            elif clause is not None and s:
+                clause["text"] += " " + s
+
+    # Token sets: text and section title kept separate so a title (topic) match
+    # can be weighted higher. Union is used for the IDF table.
+    for c in index:
+        c["text_tokens"] = set(_tokens(c["text"]))
+        c["title_tokens"] = set(_tokens(c["section_title"]))
+        c["tokens"] = c["text_tokens"] | c["title_tokens"]
+    N = len(index)
+    df = {}
+    for c in index:
+        for t in c["tokens"]:
+            df[t] = df.get(t, 0) + 1
+    idf = {t: math.log(N / (1 + n)) + 1 for t, n in df.items()}
+    return {"clauses": index, "idf": idf}
+
+
+# A match must clear this IDF-weighted score AND hit 2+ distinct query terms.
+SCORE_MIN = 3.0
+MATCH_MIN = 2
+# Matching a clause's section heading is strong topic evidence; weight it.
+TITLE_BONUS = 1.0
+# If the best clause from a DIFFERENT document scores within this fraction of the
+# top clause, the question is genuinely cross-document ambiguous → refuse rather
+# than risk a misleading single-source pick (e.g. the personal-phone trap).
+AMBIGUITY_MARGIN = 0.10
+
+
+def _expand(qtokens):
+    expanded = list(qtokens)
+    for t in qtokens:
+        expanded.extend(SYNONYMS.get(t, []))
+    return set(expanded)
+
+
+def answer_question(question: str, index: dict) -> str:
+    """Return one cited clause, or the verbatim refusal template. Never blends."""
+    qtokens = _expand(_tokens(question))
+    idf = index["idf"]
+
+    scored = []
+    for c in index["clauses"]:
+        title_hits = qtokens & c["title_tokens"]
+        # Section-topic words count once (via the title); only the non-title text
+        # words distinguish clauses within the same section (e.g. 5.2's "approval").
+        text_extra_hits = (qtokens & c["text_tokens"]) - c["title_tokens"]
+        score = (sum(idf.get(t, 0.0) for t in text_extra_hits)
+                 + TITLE_BONUS * sum(idf.get(t, 0.0) for t in title_hits))
+        n_hits = len(text_extra_hits | title_hits)
+        scored.append((score, n_hits, c))
+
+    score, n_hits, best = max(scored, key=lambda x: x[0])
+    if score < SCORE_MIN or n_hits < MATCH_MIN:
+        return REFUSAL
+
+    # Cross-document ambiguity: if another document's best clause is nearly as
+    # strong, refuse rather than commit to one side of a blend.
+    rival = max((s for s, _, c in scored if c["doc_name"] != best["doc_name"]), default=0.0)
+    if rival >= score * (1 - AMBIGUITY_MARGIN):
+        return REFUSAL
+
+    return (f"[{best['doc_name']} · Section {best['clause_id']}]\n"
+            f"\"{best['text']}\"")
+
+
+TEST_QUESTIONS = [
+    "Can I carry forward unused annual leave?",
+    "Can I install Slack on my work laptop?",
+    "What is the home office equipment allowance?",
+    "Can I use my personal phone to access work files when working from home?",
+    "What is the company view on flexible working culture?",
+    "Can I claim DA and meal receipts on the same day?",
+    "Who approves leave without pay?",
+]
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-X Ask My Documents")
+    parser.add_argument("--selftest", action="store_true", help="Run the 7 README test questions")
+    args = parser.parse_args()
+
+    index = retrieve_documents(DOCS)
+    print(f"Indexed {len(index['clauses'])} clauses from {len(DOCS)} documents.\n")
+
+    if args.selftest:
+        for q in TEST_QUESTIONS:
+            print(f"Q: {q}")
+            print(answer_question(q, index))
+            print("-" * 70)
+        return
+
+    print("Ask a policy question (blank line or Ctrl-D to quit).")
+    while True:
+        try:
+            q = input("\n> ").strip()
+        except EOFError:
+            break
+        if not q:
+            break
+        print(answer_question(q, index))
+
 
 if __name__ == "__main__":
     main()

--- a/uc-x/skills.md
+++ b/uc-x/skills.md
@@ -1,16 +1,29 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-X Ask My Documents
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_documents
+    description: Loads all three policy .txt files and indexes them by document name and section/clause number.
+    input: >
+      paths (list[str]) — the HR leave, IT acceptable-use, and finance
+      reimbursement policy files. Each has numbered sections ("3. PERSONAL
+      DEVICES (BYOD)") and numbered clauses ("3.1 ...").
+    output: >
+      A flat index of clauses, each {doc_name, doc_ref, section, section_title,
+      clause_id, text}, plus an inverse-document-frequency table over clause
+      tokens used for scoring. Every clause is traceable to one document.
+    error_handling: >
+      A missing or unreadable file raises a clear error naming the path.
+      Continuation lines are folded into their clause so no source text is lost.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: answer_question
+    description: Returns a single-source cited answer for a question, or the exact refusal template — never a blend.
+    input: >
+      question (str) and the index from retrieve_documents.
+    output: >
+      Either a string containing the citation [doc_name · Section X.Y] followed by
+      the verbatim governing clause, OR the fixed refusal template. Exactly one
+      clause is ever returned; answers from two documents are never concatenated.
+    error_handling: >
+      If no single clause clears the relevance threshold, return the refusal
+      template verbatim rather than guessing or hedging. Ties or weak matches
+      resolve to refusal, not to a blended answer.


### PR DESCRIPTION
# Vibe Coding Workshop — Submission PR

**Name:** Zuhayr Khalid
**City / Group:** Pune
**Date:** 2026-06-30
**AI tool(s) used:** Claude Code (Claude Opus 4.8)

> **Scope of this PR:** UC-X (Ask My Documents) only.

---

## UC-X — Ask My Documents

**What did the naive prompt return for the cross-document test question?**
*(Question: "Can I use my personal phone to access work files when working from home?")*

> A blended, permissive answer of the shape: "Yes, personal phones can be used for
> approved remote-work tools and email" — stitching IT BYOD language to HR
> remote-work phrasing and granting permission that no single clause actually gives.

**Did it blend the IT and HR policies?**

> Yes — that is the trap. The naive answer fused IT section 3 (personal devices)
> with HR remote-work language into one sentence.

**After your fix — what does your system return for this question?**

> The exact refusal template. The retriever finds the top candidates straddle two
> documents with near-identical scores (IT corporate-device vs Finance WFH vs IT
> personal-device) — genuine cross-document ambiguity — so it refuses rather than
> commit to one side of a blend. This is the README-endorsed behaviour ("Answer
> from IT 3.1 only, OR refuse if the combination creates genuine ambiguity").

**Did your system use any hedging phrases in any answer?**

> No. By construction every answer is either a verbatim cited clause or the exact
> refusal template — there is no free-text path, so "while not explicitly covered",
> "typically", "generally understood" cannot occur.

**Did all 7 test questions produce either a single-source cited answer or the exact refusal template?**

> Yes — all 7. Results:
> 1. Carry forward annual leave → [policy_hr_leave.txt · 2.6]
> 2. Install Slack on work laptop → [policy_it_acceptable_use.txt · 2.3]
> 3. Home office equipment allowance → [policy_finance_reimbursement.txt · 3.1]
> 4. Personal phone for work files (trap) → **refusal template**
> 5. Flexible working culture → **refusal template**
> 6. DA + meal receipts same day → [policy_finance_reimbursement.txt · 2.6]
> 7. Who approves LWP → [policy_hr_leave.txt · 5.2] (Department Head AND HR Director)
>
> 6/7 land on the exact expected clause; Q4 refuses, which the README lists as a
> correct outcome. No answer ever combines two documents.

**Your git commit message for UC-X:**

> ```
> UC-X Fix condition dropping + blending: stub raised NotImplementedError →
> implemented single-source retrieval that cites one clause or refuses
> ```

---

## Notes for reviewer

- `answer_question` returns **exactly one clause** — cross-document blending is
  structurally impossible, not merely discouraged.
- Three guards: (1) weak match → refuse; (2) section-title weighting + non-title
  tie-break routes to the governing clause; (3) cross-document near-tie → refuse
  (this is what catches the personal-phone trap).
- Run interactively: `python app.py`. Reproduce the table: `python app.py --selftest`.
- This PR is scoped to UC-X; UC-0A, UC-0B, and UC-0C are submitted in their own PRs.
