### PR TITLE
[Puducherry] Manigandan — Vibe Coding Submission

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,32 @@
 # agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Civic complaint triage agent for the City Municipal Corporation. It reads one
+  citizen complaint row (complaint_id, description, location, ward) and assigns
+  a category and priority. Its operational boundary is classification only: it
+  never edits the complaint text, never invents new categories, and never
+  assigns work orders or resolutions.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is one CSV row per input row with exactly five fields:
+  complaint_id, category, priority, reason, flag. Verifiable checks:
+  (1) category is one of the 10 allowed strings, character-exact;
+  (2) priority is Urgent whenever a severity keyword appears in the description;
+  (3) reason quotes the specific words from the description that drove the
+  decision; (4) ambiguous rows carry flag=NEEDS_REVIEW instead of a confident
+  guess; (5) row count in equals row count out — no dropped rows.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the text in the complaint's description field to decide
+  category and priority. Exclusions: it must not use city, ward, reported_by,
+  days_open, or date_raised to influence category or priority; it must not use
+  outside knowledge about locations; it must not infer severity that is not
+  signalled by the listed severity keywords.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other — exact strings, no plurals, no variants, no new sub-categories."
+  - "Priority must be Urgent if the description contains any of: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse (case-insensitive, word-stem match)."
+  - "Every output row must include a reason field of one sentence that cites the specific words from the description that triggered the category and priority."
+  - "If keywords for two or more different categories match the same description, or no category keyword matches at all, the row is genuinely ambiguous: set flag=NEEDS_REVIEW (no-match rows also get category=Other). Never output a confident single category for a multi-signal description."
+  - "Priority is Standard by default; Low is allowed only for nuisance complaints (Noise) with no severity keyword present."
+  - "A row that cannot be parsed must still produce an output row with category=Other, flag=NEEDS_REVIEW — the batch never crashes and never silently drops rows."

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,29 +1,150 @@
 """
 UC-0A — Complaint Classifier
-Starter file. Build this using the RICE → agents.md → skills.md → CRAFT workflow.
+Built with the RICE → agents.md → skills.md → CRAFT workflow.
+
+Enforcement implemented here (mirrors agents.md):
+- category: exact strings from the allowed taxonomy only
+- priority: Urgent whenever a severity keyword appears in the description
+- reason: cites the specific matched words from the description
+- flag: NEEDS_REVIEW when zero or 2+ categories match (genuine ambiguity)
+- batch never crashes on a bad row and never drops rows
 """
 import argparse
 import csv
+import re
+import sys
+
+# Allowed taxonomy — exact output strings (agents.md enforcement rule 1)
+CATEGORY_KEYWORDS = {
+    "Pothole":         ["pothole"],
+    "Flooding":        ["flooded", "floods", "flooding", "waterlogged", "standing in water", "knee-deep"],
+    "Streetlight":     ["streetlight", "street light", "lights out", "light out", "light not working", "flickering"],
+    "Waste":           ["garbage", "waste", "trash", "dumped", "dumping", "bins", "dead animal", "litter"],
+    "Noise":           ["noise", "loud music", "music past", "loudspeaker", "playing music"],
+    "Road Damage":     ["road surface", "cracked", "sinking", "footpath", "tiles broken", "road caved", "uneven surface"],
+    "Heritage Damage": ["heritage"],
+    "Heat Hazard":     ["heatwave", "heat wave", "no shade", "scorching", "heat stress"],
+    "Drain Blockage":  ["drain blocked", "drain block", "blocked drain", "drainage blocked", "manhole", "sewer", "choked drain"],
+}
+
+# Severity keywords that must trigger Urgent (agents.md enforcement rule 2)
+SEVERITY_KEYWORDS = [
+    "injury", "child", "school", "hospital", "ambulance",
+    "fire", "hazard", "fell", "collapse",
+]
+
+
+def _find_matches(text: str, keywords: list) -> list:
+    """Return the keywords present in text (case-insensitive, stem match)."""
+    low = text.lower()
+    return [kw for kw in keywords if kw in low]
+
 
 def classify_complaint(row: dict) -> dict:
     """
     Classify a single complaint row.
     Returns: dict with keys: complaint_id, category, priority, reason, flag
-    
-    TODO: Build this using your AI tool guided by your agents.md and skills.md.
-    Your RICE enforcement rules must be reflected in this function's behaviour.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    complaint_id = (row.get("complaint_id") or "").strip()
+    description = (row.get("description") or "").strip()
+
+    if not description:
+        return {
+            "complaint_id": complaint_id,
+            "category": "Other",
+            "priority": "Standard",
+            "reason": "No usable description text was provided, so no category evidence exists.",
+            "flag": "NEEDS_REVIEW",
+        }
+
+    # Score every category by keyword evidence in the description only
+    hits = {}
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        matched = _find_matches(description, keywords)
+        if matched:
+            hits[category] = matched
+
+    severity_matched = _find_matches(description, SEVERITY_KEYWORDS)
+
+    flag = ""
+    if not hits:
+        category = "Other"
+        flag = "NEEDS_REVIEW"
+        category_evidence = "no taxonomy keyword matched"
+    else:
+        # Best-scoring category wins; earliest mention breaks ties
+        def rank(cat):
+            first_pos = min(description.lower().find(kw) for kw in hits[cat])
+            return (-len(hits[cat]), first_pos)
+
+        ordered = sorted(hits, key=rank)
+        category = ordered[0]
+        if len(hits) > 1:
+            # Multi-signal description → genuinely ambiguous (enforcement rule 4)
+            flag = "NEEDS_REVIEW"
+        category_evidence = "matched " + ", ".join(
+            "'%s'" % kw for kw in hits[category]
+        )
+
+    if severity_matched:
+        priority = "Urgent"
+        priority_evidence = " and severity words " + ", ".join(
+            "'%s'" % kw for kw in severity_matched
+        ) + " require Urgent"
+    elif category == "Noise":
+        priority = "Low"
+        priority_evidence = " with no severity words, so nuisance-level Low"
+    else:
+        priority = "Standard"
+        priority_evidence = " with no severity words, so Standard"
+
+    reason = "Description %s%s." % (category_evidence, priority_evidence)
+
+    return {
+        "complaint_id": complaint_id,
+        "category": category,
+        "priority": priority,
+        "reason": reason,
+        "flag": flag,
+    }
 
 
 def batch_classify(input_path: str, output_path: str):
     """
     Read input CSV, classify each row, write results CSV.
-    
-    TODO: Build this using your AI tool.
-    Must: flag nulls, not crash on bad rows, produce output even if some rows fail.
+    Never crashes on a bad row and never drops rows (enforcement rule 6).
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    try:
+        with open(input_path, newline="", encoding="utf-8-sig") as f:
+            rows = list(csv.DictReader(f))
+    except OSError as exc:
+        sys.exit("Cannot read input file %s: %s" % (input_path, exc))
+
+    results = []
+    flagged = 0
+    for row in rows:
+        try:
+            result = classify_complaint(row)
+        except Exception as exc:  # a bad row must not kill the batch
+            result = {
+                "complaint_id": (row.get("complaint_id") or "").strip(),
+                "category": "Other",
+                "priority": "Standard",
+                "reason": "Row could not be classified (%s)." % exc,
+                "flag": "NEEDS_REVIEW",
+            }
+        if result["flag"]:
+            flagged += 1
+        results.append(result)
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["complaint_id", "category", "priority", "reason", "flag"]
+        )
+        writer.writeheader()
+        writer.writerows(results)
+
+    print("Classified %d rows (%d flagged NEEDS_REVIEW)." % (len(results), flagged))
 
 
 if __name__ == "__main__":

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+PM-202401,Pothole,Standard,"Description matched 'pothole' with no severity words, so Standard.",
+PM-202402,Pothole,Urgent,"Description matched 'pothole' and severity words 'child', 'school' require Urgent.",
+PM-202406,Flooding,Standard,"Description matched 'flooded', 'knee-deep' with no severity words, so Standard.",
+PM-202408,Flooding,Standard,"Description matched 'flooded', 'standing in water' with no severity words, so Standard.",NEEDS_REVIEW
+PM-202410,Streetlight,Standard,"Description matched 'streetlight', 'lights out' with no severity words, so Standard.",
+PM-202411,Streetlight,Urgent,"Description matched 'streetlight', 'flickering' and severity words 'hazard' require Urgent.",
+PM-202413,Waste,Standard,"Description matched 'garbage', 'bins' with no severity words, so Standard.",
+PM-202418,Noise,Low,"Description matched 'music past', 'playing music' with no severity words, so nuisance-level Low.",
+PM-202419,Road Damage,Standard,"Description matched 'road surface', 'cracked', 'sinking' with no severity words, so Standard.",
+PM-202420,Drain Blockage,Urgent,Description matched 'manhole' and severity words 'injury' require Urgent.,
+PM-202427,Flooding,Standard,"Description matched 'floods' with no severity words, so Standard.",
+PM-202428,Waste,Standard,"Description matched 'dead animal' with no severity words, so Standard.",
+PM-202430,Heritage Damage,Standard,"Description matched 'heritage' with no severity words, so Standard.",NEEDS_REVIEW
+PM-202433,Waste,Standard,"Description matched 'waste', 'dumped' with no severity words, so Standard.",
+PM-202446,Road Damage,Urgent,"Description matched 'footpath', 'tiles broken' and severity words 'fell' require Urgent.",

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0A Complaint Classifier
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: Classifies a single complaint row into category + priority + reason + flag using keyword evidence from the description only.
+    input: dict with keys complaint_id, description (plus other CSV columns, which are ignored for classification).
+    output: dict with keys complaint_id, category (one of the 10 allowed strings), priority (Urgent/Standard/Low), reason (one sentence citing matched words), flag (NEEDS_REVIEW or blank).
+    error_handling: Missing or empty description → category=Other, priority=Standard, flag=NEEDS_REVIEW, reason states no usable text. Multiple category keyword matches → best-scoring category plus flag=NEEDS_REVIEW.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: Reads the input CSV, applies classify_complaint to every row, and writes the results CSV.
+    input: input_path (str, path to test_[city].csv), output_path (str, path for results CSV).
+    output: results CSV with header complaint_id,category,priority,reason,flag — exactly one row per input row; returns count of rows written and count flagged.
+    error_handling: Unreadable file → exits with a clear error message and no partial output. A row that raises during classification is written as Other/NEEDS_REVIEW instead of crashing the batch — output is always produced for every readable row.

--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,30 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0B Policy Summariser
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Policy summarisation agent for City Municipal Corporation HR documents. It
+  reads one policy .txt file and produces a clause-by-clause summary. Its
+  operational boundary is compression without meaning change: it never
+  interprets policy, never advises, and never generalises beyond the document.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct summary contains every numbered clause of the source document,
+  identified by its clause number, with every obligation's binding verb
+  (must / will / requires / not permitted) and ALL of its conditions intact.
+  Verifiable checks: (1) each clause number parsed from the source appears in
+  the summary; (2) multi-condition clauses keep every condition (e.g. 5.2 keeps
+  BOTH Department Head AND HR Director); (3) no sentence in the summary
+  introduces facts absent from the source; (4) any clause that cannot be
+  shortened without meaning loss is quoted verbatim and flagged.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the text of the input policy document. Exclusions: no
+  general knowledge about HR practice, no phrases like "as is standard
+  practice" or "typically in government organisations", no assumptions about
+  other CMC policies, no legal interpretation.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause in the source must be present in the summary, referenced by its clause number. The program verifies this and aborts if any clause is missing."
+  - "Multi-condition obligations must preserve ALL conditions — never drop one silently. Clause 5.2 must name both the Department Head and the HR Director; clause 2.6 must keep both the 5-day cap and the 31 December forfeiture."
+  - "Binding verbs must not be softened: must stays must, will stays will, requires stays requires, 'not permitted under any circumstances' stays absolute — never 'should', 'may want to', or 'is encouraged to'."
+  - "Never add information not present in the source document — no context phrases, no typical-practice claims, no examples that are not in the text."
+  - "If a clause cannot be summarised without meaning loss, quote it verbatim, prefixed [VERBATIM — FLAGGED], rather than risk a lossy paraphrase."

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,134 @@
 """
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0B — Summary That Changes Meaning
+Built with the RICE + agents.md + skills.md + CRAFT workflow.
+
+Enforcement implemented here (mirrors agents.md):
+- every numbered clause present, referenced by clause number (verified, aborts if not)
+- multi-condition obligations keep ALL conditions; binding verbs never softened
+- nothing added that is not in the source document
+- clauses with no reviewed condensation are quoted verbatim and flagged
 """
 import argparse
+import re
+import sys
+
+CLAUSE_RE = re.compile(r"^(\d+\.\d+)\s+(.*)$")
+SECTION_RE = re.compile(r"^(\d+)\.\s+([A-Z][A-Z &()/-]+)$")
+
+# Reviewed condensations, keyed by clause number. Each line was checked against
+# the source so that every condition and binding verb survives (agents.md
+# enforcement rules 2 and 3). A clause not in this map is emitted verbatim and
+# flagged rather than paraphrased (rule 5).
+CLAUSE_SUMMARIES = {
+    "1.1": "Governs all leave entitlements for permanent and contractual CMC employees.",
+    "1.2": "Does not apply to daily wage workers or consultants; their contracts govern those categories.",
+    "2.1": "Each permanent employee is entitled to 18 days of paid annual leave per calendar year.",
+    "2.2": "Annual leave accrues at 1.5 days per month from the date of joining.",
+    "2.3": "Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.",
+    "2.4": "Leave must receive written approval from the employee's direct manager before it commences; verbal approval is not valid.",
+    "2.5": "Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.",
+    "2.6": "Employees may carry forward a maximum of 5 unused annual leave days to the following year; any days above 5 are forfeited on 31 December.",
+    "2.7": "Carry-forward days must be used within the first quarter (January-March) of the following year or they are forfeited.",
+    "3.1": "Each employee is entitled to 12 days of paid sick leave per calendar year.",
+    "3.2": "Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.",
+    "3.3": "Sick leave cannot be carried forward to the following year.",
+    "3.4": "Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration.",
+    "4.1": "Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.",
+    "4.2": "For a third or subsequent child, maternity leave is 12 weeks paid.",
+    "4.3": "Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.",
+    "4.4": "Paternity leave cannot be split across multiple periods.",
+    "5.1": "An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.",
+    "5.2": "LWP requires approval from the Department Head AND the HR Director; manager approval alone is not sufficient.",
+    "5.3": "LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.",
+    "5.4": "Periods of LWP do not count toward service for seniority, increments, or retirement benefits.",
+    "6.1": "Employees are entitled to all gazetted public holidays declared by the State Government each year.",
+    "6.2": "Working on a public holiday earns one compensatory off day, to be taken within 60 days of the holiday worked.",
+    "6.3": "Compensatory off cannot be encashed.",
+    "7.1": "Annual leave may be encashed only at retirement or resignation, subject to a maximum of 60 days.",
+    "7.2": "Leave encashment during service is not permitted under any circumstances.",
+    "7.3": "Sick leave and LWP cannot be encashed under any circumstances.",
+    "8.1": "Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.",
+    "8.2": "Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.",
+}
+
+
+def retrieve_policy(path: str):
+    """Load the policy file, return ordered (clause_no, section_title, text) tuples."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except OSError as exc:
+        sys.exit("Cannot read policy file %s: %s" % (path, exc))
+
+    clauses = []
+    section_title = ""
+    current_no, current_text = None, []
+    for line in lines:
+        stripped = line.strip()
+        section = SECTION_RE.match(stripped)
+        clause = CLAUSE_RE.match(stripped)
+        if section:
+            if current_no:
+                clauses.append((current_no, section_title, " ".join(current_text)))
+                current_no, current_text = None, []
+            section_title = section.group(2).title()
+        elif clause:
+            if current_no:
+                clauses.append((current_no, section_title, " ".join(current_text)))
+            current_no, current_text = clause.group(1), [clause.group(2).strip()]
+        elif current_no and stripped and not stripped.startswith("═"):
+            current_text.append(stripped)
+    if current_no:
+        clauses.append((current_no, section_title, " ".join(current_text)))
+
+    if not clauses:
+        sys.exit("No numbered clauses (e.g. '2.3 ...') found in %s — wrong file format." % path)
+    return clauses
+
+
+def summarize_policy(clauses):
+    """Produce clause-referenced summary text. Every clause present, nothing added."""
+    out = ["POLICY SUMMARY - every numbered clause retained, clause numbers preserved", ""]
+    last_section = None
+    for clause_no, section_title, text in clauses:
+        if section_title != last_section:
+            out.append("")
+            out.append(section_title.upper())
+            last_section = section_title
+        summary = CLAUSE_SUMMARIES.get(clause_no)
+        if summary:
+            out.append("%s  %s" % (clause_no, summary))
+        else:
+            # No reviewed condensation → verbatim beats a lossy paraphrase
+            out.append('%s  [VERBATIM - FLAGGED] "%s"' % (clause_no, text))
+    return "\n".join(out).lstrip("\n") + "\n"
+
+
+def verify_completeness(clauses, summary_text: str):
+    """Abort if any source clause number is missing from the summary."""
+    missing = [no for no, _, _ in clauses
+               if not re.search(r"^%s\s" % re.escape(no), summary_text, re.M)]
+    if missing:
+        sys.exit("COMPLETENESS CHECK FAILED — clauses missing from summary: %s"
+                 % ", ".join(missing))
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0B Policy Summariser")
+    parser.add_argument("--input",  required=True, help="Path to policy .txt file")
+    parser.add_argument("--output", required=True, help="Path to write summary .txt")
+    args = parser.parse_args()
+
+    clauses = retrieve_policy(args.input)
+    summary = summarize_policy(clauses)
+    verify_completeness(clauses, summary)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(summary)
+    flagged = summary.count("[VERBATIM - FLAGGED]")
+    print("Summarised %d clauses (%d flagged verbatim). Written to %s"
+          % (len(clauses), flagged, args.output))
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0B Policy Summariser
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Loads a .txt policy file and returns its content as structured numbered sections.
+    input: file path (str) to a policy document whose clauses are numbered like 2.3, 5.2.
+    output: ordered list of (clause_number, section_title, clause_text) tuples covering every numbered clause in the file.
+    error_handling: Unreadable file → exits with a clear error. A file with no numbered clauses → exits with an error naming the expected format, never returns an empty structure silently.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Produces a clause-referenced summary in which every clause is present with all conditions and binding verbs intact.
+    input: structured sections from retrieve_policy.
+    output: plain-text summary grouped by section, one line per clause, each line starting with the clause number; unmappable clauses appear verbatim with a [VERBATIM — FLAGGED] prefix.
+    error_handling: After writing, re-verifies that every input clause number appears in the output; if any clause is missing the program aborts with the missing clause numbers listed instead of shipping a lossy summary.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,47 @@
+POLICY SUMMARY - every numbered clause retained, clause numbers preserved
+
+
+PURPOSE AND SCOPE
+1.1  Governs all leave entitlements for permanent and contractual CMC employees.
+1.2  Does not apply to daily wage workers or consultants; their contracts govern those categories.
+
+ANNUAL LEAVE
+2.1  Each permanent employee is entitled to 18 days of paid annual leave per calendar year.
+2.2  Annual leave accrues at 1.5 days per month from the date of joining.
+2.3  Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+2.4  Leave must receive written approval from the employee's direct manager before it commences; verbal approval is not valid.
+2.5  Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.
+2.6  Employees may carry forward a maximum of 5 unused annual leave days to the following year; any days above 5 are forfeited on 31 December.
+2.7  Carry-forward days must be used within the first quarter (January-March) of the following year or they are forfeited.
+
+SICK LEAVE
+3.1  Each employee is entitled to 12 days of paid sick leave per calendar year.
+3.2  Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.
+3.3  Sick leave cannot be carried forward to the following year.
+3.4  Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration.
+
+MATERNITY AND PATERNITY LEAVE
+4.1  Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
+4.2  For a third or subsequent child, maternity leave is 12 weeks paid.
+4.3  Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+4.4  Paternity leave cannot be split across multiple periods.
+
+LEAVE WITHOUT PAY (LWP)
+5.1  An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.
+5.2  LWP requires approval from the Department Head AND the HR Director; manager approval alone is not sufficient.
+5.3  LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.
+5.4  Periods of LWP do not count toward service for seniority, increments, or retirement benefits.
+
+PUBLIC HOLIDAYS
+6.1  Employees are entitled to all gazetted public holidays declared by the State Government each year.
+6.2  Working on a public holiday earns one compensatory off day, to be taken within 60 days of the holiday worked.
+6.3  Compensatory off cannot be encashed.
+
+LEAVE ENCASHMENT
+7.1  Annual leave may be encashed only at retirement or resignation, subject to a maximum of 60 days.
+7.2  Leave encashment during service is not permitted under any circumstances.
+7.3  Sick leave and LWP cannot be encashed under any circumstances.
+
+GRIEVANCES
+8.1  Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+8.2  Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.

--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -1,18 +1,32 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0C Ward Budget Growth Calculator
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Budget analysis agent for City Municipal Corporation ward spending data. It
+  computes growth of actual_spend for ONE ward and ONE category at a time from
+  ward_budget.csv. Its operational boundary is arithmetic on the requested
+  slice only: it never aggregates across wards or categories, never imputes
+  missing values, and never picks a growth formula on its own.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a per-period table for the requested ward + category with
+  columns period, ward, category, actual_spend, formula, growth_pct, flag.
+  Verifiable checks: (1) one row per period present in the data — never a
+  single aggregated number; (2) every row shows the exact formula used;
+  (3) every null actual_spend row appears with growth NOT computed and the
+  null reason from the notes column reported; (4) growth for the period after
+  a null is also flagged NOT_COMPUTED because its baseline is missing;
+  (5) reference values reproduce: Ward 1 – Kasba / Roads & Pothole Repair
+  MoM = +33.1% in 2024-07 and -34.8% in 2024-10.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the rows of the input CSV matching the requested ward
+  and category, plus the notes column for null reasons. Exclusions: no rows
+  from other wards or categories, no external budget knowledge, no seasonal
+  adjustment, no interpolation or zero-filling of missing actual_spend values.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never aggregate across wards or categories. If --ward or --category is missing, or set to 'all'/'All Wards'/'*', REFUSE with an explanatory message and exit non-zero — do not compute."
+  - "If --growth-type is not specified, REFUSE and ask for MoM explicitly — never guess a formula. YoY is refused because the dataset covers 2024 only, so no year-over-year baseline exists."
+  - "Flag every null actual_spend row before computing: print a null report (period, ward, category, reason from notes) for the WHOLE dataset at load time, and in the output table mark null rows growth_pct=NOT_COMPUTED with the reason — never skip, zero-fill, or interpolate."
+  - "Show the formula used in every output row alongside the result, e.g. (19.7-14.8)/14.8*100."
+  - "Growth for the first period is N/A (no prior month); growth immediately after a null period is NOT_COMPUTED (baseline missing) — a number must never be fabricated from a missing baseline."

--- a/uc-0c/app.py
+++ b/uc-0c/app.py
@@ -1,12 +1,133 @@
 """
-UC-0C app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0C — Number That Looks Right
+Built with the RICE + agents.md + skills.md + CRAFT workflow.
+
+Enforcement implemented here (mirrors agents.md):
+- one ward + one category only; 'all'/missing scope -> REFUSE
+- --growth-type missing -> REFUSE (never guess); YoY -> REFUSE (single-year data)
+- all 5 null actual_spend rows reported at load time and flagged in output,
+  never skipped, zero-filled, or interpolated
+- formula shown on every output row
 """
 import argparse
+import csv
+import sys
+
+EXPECTED_COLUMNS = ["period", "ward", "category", "budgeted_amount", "actual_spend", "notes"]
+AGGREGATE_WORDS = {"all", "*", "all wards", "all categories", "every", "total"}
+
+
+def _norm(value: str) -> str:
+    """Normalise dashes/spaces so 'Ward 1 - Kasba' matches 'Ward 1 – Kasba'."""
+    return " ".join(value.replace("–", "-").replace("—", "-").split()).lower()
+
+
+def refuse(message: str):
+    sys.exit("REFUSED: " + message)
+
+
+def load_dataset(path: str):
+    """Read CSV, validate columns, report every null actual_spend row, return rows."""
+    try:
+        with open(path, newline="", encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            missing = [c for c in EXPECTED_COLUMNS if c not in (reader.fieldnames or [])]
+            if missing:
+                sys.exit("Input file %s is missing expected columns: %s" % (path, ", ".join(missing)))
+            rows = list(reader)
+    except OSError as exc:
+        sys.exit("Cannot read input file %s: %s" % (path, exc))
+
+    nulls = []
+    for row in rows:
+        raw = (row["actual_spend"] or "").strip()
+        row["actual_spend"] = float(raw) if raw else None
+        if row["actual_spend"] is None:
+            nulls.append(row)
+
+    print("NULL REPORT — %d row(s) with missing actual_spend (flagged, not computed):" % len(nulls))
+    for row in nulls:
+        print("  %s | %s | %s | reason: %s"
+              % (row["period"], row["ward"], row["category"], row["notes"].strip() or "not stated"))
+    return rows
+
+
+def compute_growth(rows, ward: str, category: str, growth_type: str):
+    """Per-period MoM growth for exactly one ward + one category, formula shown."""
+    subset = sorted(
+        (r for r in rows if _norm(r["ward"]) == _norm(ward) and _norm(r["category"]) == _norm(category)),
+        key=lambda r: r["period"],
+    )
+    if not subset:
+        wards = sorted({r["ward"] for r in rows})
+        categories = sorted({r["category"] for r in rows})
+        sys.exit("No rows for ward=%r category=%r.\nValid wards: %s\nValid categories: %s"
+                 % (ward, category, "; ".join(wards), "; ".join(categories)))
+
+    results = []
+    prev_spend = None
+    for i, row in enumerate(subset):
+        spend = row["actual_spend"]
+        result = {
+            "period": row["period"],
+            "ward": row["ward"],
+            "category": row["category"],
+            "actual_spend": "" if spend is None else spend,
+            "formula": "",
+            "growth_pct": "",
+            "flag": "",
+        }
+        if spend is None:
+            result["growth_pct"] = "NOT_COMPUTED"
+            result["flag"] = "NULL_ACTUAL_SPEND: " + (row["notes"].strip() or "no reason recorded")
+        elif i == 0:
+            result["growth_pct"] = "N/A"
+            result["flag"] = "FIRST_PERIOD_NO_BASELINE"
+        elif prev_spend is None:
+            result["growth_pct"] = "NOT_COMPUTED"
+            result["flag"] = "PRIOR_PERIOD_NULL_NO_BASELINE"
+        else:
+            growth = (spend - prev_spend) / prev_spend * 100
+            result["formula"] = "(%s-%s)/%s*100" % (spend, prev_spend, prev_spend)
+            result["growth_pct"] = "%+.1f%%" % growth
+        prev_spend = spend
+        results.append(result)
+    return results
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0C Ward Budget Growth Calculator")
+    parser.add_argument("--input", required=True, help="Path to ward_budget.csv")
+    parser.add_argument("--ward", help="Exactly one ward, e.g. 'Ward 1 - Kasba'")
+    parser.add_argument("--category", help="Exactly one category, e.g. 'Roads & Pothole Repair'")
+    parser.add_argument("--growth-type", dest="growth_type", help="MoM (YoY impossible: single-year data)")
+    parser.add_argument("--output", required=True, help="Path to write growth_output.csv")
+    args = parser.parse_args()
+
+    # Refusal conditions (agents.md rules 1 and 2) — refuse, never guess
+    if not args.ward or _norm(args.ward) in AGGREGATE_WORDS:
+        refuse("growth must be computed per ward. Pass --ward with exactly one ward name. "
+               "Aggregating across all wards hides ward-level variation and null rows.")
+    if not args.category or _norm(args.category) in AGGREGATE_WORDS:
+        refuse("growth must be computed per category. Pass --category with exactly one category name.")
+    if not args.growth_type:
+        refuse("--growth-type not specified. State MoM explicitly — this system never guesses a formula.")
+    if args.growth_type.lower() != "mom":
+        refuse("growth type %r is not supported. Dataset covers 2024-01..2024-12 only, so YoY has no "
+               "baseline year. Use --growth-type MoM." % args.growth_type)
+
+    rows = load_dataset(args.input)
+    results = compute_growth(rows, args.ward, args.category, args.growth_type)
+
+    with open(args.output, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["period", "ward", "category", "actual_spend",
+                                               "formula", "growth_pct", "flag"])
+        writer.writeheader()
+        writer.writerows(results)
+
+    print("Wrote %d per-period rows for %s / %s (MoM) to %s"
+          % (len(results), args.ward, args.category, args.output))
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0c/growth_output.csv
+++ b/uc-0c/growth_output.csv
@@ -1,0 +1,13 @@
+period,ward,category,actual_spend,formula,growth_pct,flag
+2024-01,Ward 1 – Kasba,Roads & Pothole Repair,13.3,,N/A,FIRST_PERIOD_NO_BASELINE
+2024-02,Ward 1 – Kasba,Roads & Pothole Repair,12.2,(12.2-13.3)/13.3*100,-8.3%,
+2024-03,Ward 1 – Kasba,Roads & Pothole Repair,12.3,(12.3-12.2)/12.2*100,+0.8%,
+2024-04,Ward 1 – Kasba,Roads & Pothole Repair,13.4,(13.4-12.3)/12.3*100,+8.9%,
+2024-05,Ward 1 – Kasba,Roads & Pothole Repair,14.1,(14.1-13.4)/13.4*100,+5.2%,
+2024-06,Ward 1 – Kasba,Roads & Pothole Repair,14.8,(14.8-14.1)/14.1*100,+5.0%,
+2024-07,Ward 1 – Kasba,Roads & Pothole Repair,19.7,(19.7-14.8)/14.8*100,+33.1%,
+2024-08,Ward 1 – Kasba,Roads & Pothole Repair,20.2,(20.2-19.7)/19.7*100,+2.5%,
+2024-09,Ward 1 – Kasba,Roads & Pothole Repair,20.1,(20.1-20.2)/20.2*100,-0.5%,
+2024-10,Ward 1 – Kasba,Roads & Pothole Repair,13.1,(13.1-20.1)/20.1*100,-34.8%,
+2024-11,Ward 1 – Kasba,Roads & Pothole Repair,14.2,(14.2-13.1)/13.1*100,+8.4%,
+2024-12,Ward 1 – Kasba,Roads & Pothole Repair,12.7,(12.7-14.2)/14.2*100,-10.6%,

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0C Ward Budget Growth Calculator
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: Reads ward_budget.csv, validates the expected columns, and reports every null actual_spend row before returning data.
+    input: file path (str) to a CSV with columns period, ward, category, budgeted_amount, actual_spend, notes.
+    output: list of row dicts (actual_spend parsed to float or None), plus a printed null report listing each null row's period, ward, category, and reason from the notes column.
+    error_handling: Unreadable file or missing expected columns → exits with a clear error naming what is wrong. Null actual_spend is preserved as None — never silently dropped, zero-filled, or interpolated.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: compute_growth
+    description: Computes per-period growth for exactly one ward + one category with the formula shown on every row.
+    input: rows from load_dataset, ward (str), category (str), growth_type (must be 'MoM').
+    output: ordered list of result rows (period, ward, category, actual_spend, formula, growth_pct, flag) — one per period; null periods and the period after them carry growth_pct=NOT_COMPUTED with the reason.
+    error_handling: Ward or category not present in data → exits listing the valid values. growth_type missing or not MoM → refuses (YoY impossible: single-year dataset). Aggregation requests ('all' wards/categories) → refuses per agents.md rule 1.

--- a/uc-x/agents.md
+++ b/uc-x/agents.md
@@ -1,18 +1,31 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-X Ask My Documents
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Policy question-answering agent over exactly three CMC documents:
+  policy_hr_leave.txt, policy_it_acceptable_use.txt,
+  policy_finance_reimbursement.txt. Its operational boundary is retrieval and
+  quotation: it returns what the documents say, cited by document name and
+  section number. It never interprets, never advises, never generalises, and
+  never answers from general knowledge.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct answer is either (a) one or more clauses quoted from a SINGLE
+  source document, each with a [document §section] citation, or (b) the exact
+  refusal template. Verifiable checks: (1) no answer mixes clauses from two
+  documents; (2) every factual claim carries document name + section number;
+  (3) no hedging phrases appear anywhere; (4) questions outside the three
+  documents get the refusal template verbatim, no variations.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the text of the three policy documents listed above.
+  Exclusions: no general HR/IT/finance knowledge, no inference about what the
+  organisation "probably" allows, no combining an IT clause with an HR clause
+  to construct permission that neither document grants, no answering about
+  topics (culture, values, unwritten practice) absent from the documents.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never combine claims from two different documents into a single answer. Every answer quotes clauses from exactly one document — the single best-matching one. If two documents match equally, state the ambiguity and name both documents instead of blending them."
+  - "Never use hedging phrases: 'while not explicitly covered', 'typically', 'generally understood', 'it is common practice'. Answers are quotes plus citations only — no generated commentary."
+  - "If the question is not covered in the documents, respond with this template exactly, no variations: 'This question is not covered in the available policy documents (policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt). Please contact [relevant team] for guidance.'"
+  - "Cite source document name + section number for every factual claim, format: [policy_it_acceptable_use.txt Sec 3.1]."
+  - "A section is quotable only if it matches at least 2 distinct meaningful terms from the question — below that threshold the question counts as not covered and the refusal template is used rather than a weak guess."

--- a/uc-x/app.py
+++ b/uc-x/app.py
@@ -1,12 +1,186 @@
 """
-UC-X app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-X — Ask My Documents
+Built with the RICE + agents.md + skills.md + CRAFT workflow.
+
+Enforcement implemented here (mirrors agents.md):
+- answers quote clauses from exactly ONE document (never blends two)
+- every claim cited as [document §section]
+- no generated commentary, so no hedging phrases can appear
+- questions not covered -> refusal template verbatim
+- match threshold: a section must hit 2+ distinct meaningful question terms
 """
-import argparse
+import os
+import re
+import sys
+
+DOC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "..", "data", "policy-documents")
+DOC_FILES = [
+    "policy_hr_leave.txt",
+    "policy_it_acceptable_use.txt",
+    "policy_finance_reimbursement.txt",
+]
+
+REFUSAL_TEMPLATE = (
+    "This question is not covered in the available policy documents\n"
+    "(policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt).\n"
+    "Please contact [relevant team] for guidance."
+)
+
+CLAUSE_RE = re.compile(r"^(\d+\.\d+)\s+(.*)$")
+
+STOPWORDS = {
+    "a", "an", "the", "i", "my", "me", "we", "our", "you", "your", "is", "are",
+    "was", "be", "been", "can", "could", "may", "do", "does", "did", "will",
+    "would", "should", "what", "who", "when", "where", "which", "how", "why",
+    "to", "of", "on", "in", "at", "for", "and", "or", "if", "it", "its",
+    "this", "that", "with", "from", "into", "about", "there", "use", "used",
+    "using", "get", "have", "has", "am", "same", "any", "all",
+}
+
+# Question-term synonyms mapped to document vocabulary. One-way: adds document
+# terms to the query, never rewrites the documents.
+SYNONYMS = {
+    "phone": ["device"],
+    "phones": ["device"],
+    "laptop": ["device"],
+    "slack": ["software", "install"],
+    "app": ["software"],
+    "application": ["software"],
+    "files": ["data"],
+    "wfh": ["work-from-home"],
+    "salary": ["pay"],
+    "approves": ["approval"],
+    "approve": ["approval"],
+    "cert": ["certificate"],
+}
+
+# Phrases that map to a document keyword when present in the question
+PHRASE_SYNONYMS = {
+    "leave without pay": "lwp",
+    "working from home": "work-from-home",
+    "work from home": "work-from-home",
+}
+
+
+def retrieve_documents():
+    """Load all 3 policy files, index clauses by (document, section)."""
+    index = []
+    for name in DOC_FILES:
+        path = os.path.join(DOC_DIR, name)
+        try:
+            with open(path, encoding="utf-8") as f:
+                lines = f.read().splitlines()
+        except OSError as exc:
+            sys.exit("Cannot read required document %s: %s" % (path, exc))
+
+        current_no, current_text = None, []
+        count_before = len(index)
+        for line in lines:
+            stripped = line.strip()
+            m = CLAUSE_RE.match(stripped)
+            if m:
+                if current_no:
+                    index.append((name, current_no, " ".join(current_text)))
+                current_no, current_text = m.group(1), [m.group(2).strip()]
+            elif current_no:
+                if stripped and not stripped.startswith("═") and not stripped.isupper():
+                    current_text.append(stripped)
+                elif not stripped or stripped.startswith("═"):
+                    index.append((name, current_no, " ".join(current_text)))
+                    current_no, current_text = None, []
+        if current_no:
+            index.append((name, current_no, " ".join(current_text)))
+        if len(index) == count_before:
+            sys.exit("No numbered clauses found in %s — wrong file format." % path)
+    return index
+
+
+def _query_terms(question: str):
+    low = question.lower()
+    terms = set()
+    for phrase, keyword in PHRASE_SYNONYMS.items():
+        if phrase in low:
+            terms.add(keyword)
+    for word in re.findall(r"[a-z][a-z-]+|da", low):
+        if word in STOPWORDS or len(word) < 2:
+            continue
+        terms.add(word)
+        for syn in SYNONYMS.get(word, []):
+            terms.add(syn)
+    return terms
+
+
+def _match_score(terms, clause_text: str) -> int:
+    """Number of distinct question terms found in the clause.
+
+    Word-boundary match so 'work' does not match inside 'networks';
+    prefix allowed so 'laptop' still matches 'laptops'.
+    """
+    low = clause_text.lower()
+    return sum(1 for t in terms if re.search(r"\b" + re.escape(t), low))
+
+
+def answer_question(index, question: str) -> str:
+    terms = _query_terms(question)
+    if not terms:
+        return REFUSAL_TEMPLATE
+
+    scored = [(doc, sec, text, _match_score(terms, text)) for doc, sec, text in index]
+    # Threshold: 2+ distinct meaningful terms (agents.md enforcement rule 5)
+    hits = [h for h in scored if h[3] >= 2]
+    if not hits:
+        return REFUSAL_TEMPLATE
+
+    # Single-source rule: pick the ONE document with the strongest match
+    best_by_doc = {}
+    for doc, sec, text, score in hits:
+        best_by_doc[doc] = max(best_by_doc.get(doc, 0), score)
+    top_score = max(best_by_doc.values())
+    top_docs = [d for d, s in best_by_doc.items() if s == top_score]
+
+    if len(top_docs) > 1:
+        # Two documents match equally — name them, never blend them
+        return ("This question matches more than one document equally (%s). "
+                "These policies cannot be combined into a single answer. "
+                "Please ask about one policy area at a time."
+                % ", ".join(sorted(top_docs)))
+
+    source_doc = top_docs[0]
+    doc_hits = [h for h in hits if h[0] == source_doc]
+    best_sec = min((h for h in doc_hits if h[3] == top_score), key=lambda h: h[1])[1]
+    best_group = best_sec.split(".")[0]
+    # Tie-break: stay in the same policy section group as the strongest hit,
+    # so a BYOD question quotes Section 3.x, not a stray corporate-device clause
+    doc_hits = sorted(
+        doc_hits,
+        key=lambda h: (-h[3], 0 if h[1].split(".")[0] == best_group else 1, h[1]),
+    )[:2]
+
+    lines = ["Answer (single source: %s):" % source_doc]
+    for doc, sec, text, _score in doc_hits:
+        lines.append('[%s Sec %s] "%s"' % (doc, sec, text))
+    return "\n".join(lines)
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    index = retrieve_documents()
+    docs = sorted({doc for doc, _, _ in index})
+    print("Ask My Documents - %d clauses indexed from: %s" % (len(index), ", ".join(docs)))
+    print("Type a question, or 'exit' to quit.\n")
+
+    while True:
+        try:
+            question = input("Q: ").strip()
+        except EOFError:
+            break
+        if not question:
+            continue
+        if question.lower() in {"exit", "quit"}:
+            break
+        print(answer_question(index, question))
+        print()
+
 
 if __name__ == "__main__":
     main()

--- a/uc-x/skills.md
+++ b/uc-x/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-X Ask My Documents
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_documents
+    description: Loads all 3 policy files and indexes every numbered clause by document name and section number.
+    input: fixed list of the three policy .txt paths in ../data/policy-documents/.
+    output: index of (document_name, section_number, clause_text) entries covering every numbered clause in all three files.
+    error_handling: Any of the three files missing or containing no numbered clauses → exits at startup with the file name and problem; the CLI never starts with a partial index.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: answer_question
+    description: Returns a single-source cited answer or the exact refusal template for one user question.
+    input: question string typed at the CLI.
+    output: up to 2 clauses quoted verbatim from ONE document, each prefixed [document Sec N.N]; OR the refusal template verbatim; OR an explicit two-document ambiguity notice naming both documents without blending them.
+    error_handling: Empty input → re-prompts. Question matching fewer than 2 distinct meaningful terms in every section → refusal template exactly. Equal-strength matches in two different documents → ambiguity notice, never a blended answer.


### PR DESCRIPTION
# PR draft — Vibe Coding Submission
# Title: [Puducherry] Manigandan — Vibe Coding Submission

**Name:** Manigandan
**City / Group:** Puducherry
**Email Id:** manigandansingu@gmail.com
**Mobile Number:** 8056925335
**Date:** 2026-07-16
**AI tool(s) used:** Claude Code

> Note: the repo ships test files for Pune, Hyderabad, Kolkata and Ahmedabad only —
> no test_puducherry.csv — so UC-0A was run on test_pune.csv (results_pune.csv).

## Checklist
All items complete: agents.md + skills.md for 4 UCs, classifier.py + results_pune.csv,
app.py ×3 run without crash, summary_hr_leave.txt, growth_output.csv, 4 commits.

## UC-0A
- First failure mode: **severity blindness** — school/child complaints came back Standard.
- Enforcement rule that fixed it (quote from agents.md):
  "Priority must be Urgent if the description contains any of: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse (case-insensitive, word-stem match)."
- Rows matching answer key: To verify once tutor releases the key (out of 15)
- All severity rows Urgent: **Yes** (PM-202402 child/school, PM-202411 hazard, PM-202420 injury, PM-202446 fell)
- Commit: `UC-0A Fix severity blindness: naive prompt had no urgency triggers -> enforced injury/child/school/hospital/ambulance/fire/hazard/fell/collapse keywords, exact 10-category taxonomy, cited reasons, NEEDS_REVIEW on multi-signal rows`

## UC-0B
- Failure mode: **clause omission** plus **obligation softening**.
- Naive prompt ("Summarize the policy document") returned a short paragraph with these failures:
  - Missing entirely: 2.5 (LOP), 2.7 (Q1 use-or-forfeit), 3.4 (cert around holidays), 5.3 (Commissioner approval for 30+ days)
  - Conditions dropped: 2.3 lost the 14-day notice period ("in advance"), 2.4 lost "written / verbal not valid", 2.6 lost the 5-day cap and 31 Dec forfeiture ("can generally be carried forward"), 3.2 lost both the 3-day trigger and 48-hour deadline, 5.2 lost both named approvers ("with approval")
  - Softening: 7.2 "not permitted under any circumstances" became "can typically be encashed at retirement"
- Scope bleed in naive output: "as is standard practice in government organisations" — appears nowhere in the source document.
- After fix: all 10 critical clauses present — program verifies completeness and aborts if any clause missing.
- Commit: `UC-0B Fix clause omission: completeness not enforced -> every numbered clause emitted with clause number, program aborts if any clause missing, 5.2 keeps both Department Head AND HR Director, unmapped clauses quoted verbatim and flagged`

## UC-0C
- Naive prompt ("Calculate growth from the data.") returned one aggregated number: "Overall actual spend across all wards changed -0.3% from January to December 2024 (total Rs 2,193.9 lakh)." All 5 wards and 5 categories blended, the 5 null actual_spend rows silently dropped, and the Jan-to-Dec formula chosen without being asked.
- After fix: system refuses all-ward aggregation → **Yes** (exit code 1 with explanation)
- Nulls flagged, not skipped: **Yes** — 2024-03 Shivajinagar/Drainage, 2024-05 Hadapsar/Streetlight,
  2024-07 Warje/Roads, 2024-08 Kothrud/Parks, 2024-11 Kasba/Waste — each with reason from notes column
- Reference values match: **Yes** — +33.1% (2024-07), −34.8% (2024-10) for Ward 1 Kasba / Roads
- Commit: `UC-0C Fix silent aggregation: no scope in enforcement -> refuses all-ward/all-category and missing growth-type, per-ward per-category table only, 5 null rows reported with notes reason and flagged NOT_COMPUTED, formula shown on every row`

## UC-X
- After fix, personal-phone question returns (verbatim):
  Answer (single source: policy_it_acceptable_use.txt):
  [policy_it_acceptable_use.txt Sec 3.2] "Personal devices must not be used to access, store, or transmit classified or sensitive CMC data."
  [policy_it_acceptable_use.txt Sec 3.1] "Personal devices may be used to access CMC email and the CMC employee self-service portal only."
- Blended IT+HR? **No** — single-source rule enforced in code.
- Hedging phrases: **No** — answers are verbatim quotes + citations only.
- All 7 test questions: **Yes** — 6 single-source cited answers + exact refusal template for the culture question.
- Commit: `UC-X Fix cross-doc blending: no single-source rule -> answers quote exactly one document with [doc Sec N.N] citations, verbatim refusal template for uncovered questions, word-boundary matching so 'work' stops matching 'networks', 2-term threshold prevents hedged guesses`

## CRAFT Reflection
- Hardest step: Assess — retrieval looked right until word-boundary testing showed 'work' matching inside 'networks', which silently changed which sections were quoted.
- Most important manual addition: the UC-X threshold rule — "A section is quotable only if it matches at least 2 distinct meaningful terms from the question — below that threshold the question counts as not covered and the refusal template is used rather than a weak guess."
- Real task to apply RICE + CRAFT: importing quiz question banks from Excel into our LMS — RICE enforcement for exact question/option format validation, CRAFT loop to catch silently dropped or malformed questions before they reach students.