### PR TITLE
UC-0A Fix taxonomy drift, severity blindness, missing justification, …

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,27 @@
 # agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  A civic complaint classification agent for Indian city municipal portals. It reads one
+  complaint row (citizen description) and returns an exact, schema-compliant classification.
+  Its operational boundary is strict: it NEVER adds new categories, NEVER guesses severity,
+  and NEVER outputs anything outside the fields in the classification schema.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  Given one complaint row, produce a verifiable 4-field classification. A correct output is
+  one where category is an exact match from the allowed list, priority follows the severity
+  keyword rule, reason is a single sentence citing specific words from the description, and
+  flag is set to NEEDS_REVIEW exactly when the category cannot be determined with confidence.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the complaint description plus the row's location, ward, and days_open
+  fields to classify. It may not assume facts not stated (e.g. no repair history, no sensor
+  readings, no prior complaints). External world knowledge is excluded except for recognising
+  the ten allowed categories and the severity keywords below.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other — exact strings, no variations or sub-categories."
+  - "priority must be Urgent if and only if the description contains any of: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse; otherwise Standard unless the complaint is a minor nuisance (see Low rule)."
+  - "priority must be Low only for genuinely minor, non-safety complaints (e.g. noise from an event, smell from bins) with no severity keyword present; anything else is Standard or Urgent."
+  - "reason must be a single sentence that cites specific words from the description justifying both category and priority; it must not cite words that are absent."
+  - "flag must be set to NEEDS_REVIEW exactly when the description maps to more than one allowed category with comparable confidence (e.g. 'road cracked near heritage street'), and must be blank otherwise."
+  - "Every output row must include complaint_id (preserved from input), category, priority, reason, and flag columns; no row may be dropped silently."

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,29 +1,150 @@
 """
 UC-0A — Complaint Classifier
-Starter file. Build this using the RICE → agents.md → skills.md → CRAFT workflow.
+Rule-based implementation guided by agents.md and skills.md.
 """
 import argparse
 import csv
+
+ALLOWED_CATEGORIES = [
+    "Pothole",
+    "Flooding",
+    "Streetlight",
+    "Waste",
+    "Noise",
+    "Road Damage",
+    "Heritage Damage",
+    "Heat Hazard",
+    "Drain Blockage",
+    "Other",
+]
+
+SEVERITY_KEYWORDS = [
+    "injury",
+    "child",
+    "school",
+    "hospital",
+    "ambulance",
+    "fire",
+    "hazard",
+    "fell",
+    "collapse",
+]
+
+CATEGORY_KEYWORDS = [
+    ("Pothole", ["pothole", "manhole"]),
+    ("Flooding", ["flood", "submerged", "water logging", "waterlogged", "standing in water", "rainwater"]),
+    ("Drain Blockage", ["drain blocked", "blocked drain", "drainage", "choked drain", "sewer", "draining"]),
+    ("Heat Hazard", ["heat", "heatwave", "sunstroke", "temperature", "melting"]),
+    ("Road Damage", ["cracked", "sinking", "road surface", "footpath", "tiles", "pavement", "asphalt", "paving", "upturned", "collapsed", "crater", "subsided", "cobblestone", "tarmac"]),
+    ("Streetlight", ["streetlight", "street light", "lights out", "light out", "flickering", "lamp", "unlit", "dark"]),
+    ("Waste", ["garbage", "waste", "bins", "bin", "dead animal", "carcass", "rubbish", "refuse", "dumped", "litter"]),
+    ("Noise", ["noise", "music", "loud", "dj", "speaker", "sound", "drilling", "idling", "band"]),
+    ("Heritage Damage", ["heritage", "historic"]),
+]
+
+LOW_HINTS = ["music", "smell", "odour", "event"]
+
 
 def classify_complaint(row: dict) -> dict:
     """
     Classify a single complaint row.
     Returns: dict with keys: complaint_id, category, priority, reason, flag
-    
-    TODO: Build this using your AI tool guided by your agents.md and skills.md.
-    Your RICE enforcement rules must be reflected in this function's behaviour.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    complaint_id = str(row.get("complaint_id", "")).strip() or "UNKNOWN"
+    description = (row.get("description") or "").strip()
+
+    if not description:
+        return {
+            "complaint_id": complaint_id,
+            "category": "Other",
+            "priority": "Standard",
+            "reason": "The description is empty so no category can be determined.",
+            "flag": "NEEDS_REVIEW",
+        }
+
+    desc_lower = description.lower()
+
+    matched = []
+    for category, keywords in CATEGORY_KEYWORDS:
+        hits = [kw for kw in keywords if kw in desc_lower]
+        if not hits and category == "Drain Blockage" and "drain" in desc_lower and "blocked" in desc_lower:
+            hits = ["drain ... blocked"]
+        if hits:
+            matched.append((category, hits))
+
+    flag = ""
+    if matched:
+        heritage_present = any(c == "Heritage Damage" for c, _ in matched)
+        if heritage_present and len(matched) > 1:
+            category, _ = next(m for m in matched if m[0] != "Heritage Damage")
+            flag = "NEEDS_REVIEW"
+        else:
+            category, _ = matched[0]
+    else:
+        category = "Other"
+        flag = "NEEDS_REVIEW"
+
+    matched_words = [w for _, hits in matched for w in hits]
+    severity_hits = [kw for kw in SEVERITY_KEYWORDS if kw in desc_lower]
+
+    if severity_hits:
+        priority = "Urgent"
+    elif category == "Noise" or (category == "Waste" and any(h in desc_lower for h in LOW_HINTS)):
+        priority = "Low"
+    else:
+        priority = "Standard"
+
+    reason = _build_reason(category, priority, matched_words, severity_hits, flag)
+
+    return {
+        "complaint_id": complaint_id,
+        "category": category,
+        "priority": priority,
+        "reason": reason,
+        "flag": flag,
+    }
+
+
+def _build_reason(category, priority, matched_words, severity_hits, flag) -> str:
+    cited = ", ".join(f"'{w}'" for w in matched_words)
+    if not cited:
+        cited = "no known category keyword"
+    category_part = f"The description cites {cited}, so category is {category}"
+    if severity_hits:
+        sev = ", ".join(f"'{w}'" for w in severity_hits)
+        priority_part = f"priority is {priority} because it cites {sev}"
+    elif priority == "Low":
+        priority_part = f"priority is {priority} because no severity keyword is cited and the issue is a minor nuisance"
+    else:
+        priority_part = f"priority is {priority} because no severity keyword is cited"
+    flag_part = f", and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence" if flag else ""
+    return f"{category_part}, {priority_part}{flag_part}."
 
 
 def batch_classify(input_path: str, output_path: str):
     """
     Read input CSV, classify each row, write results CSV.
-    
-    TODO: Build this using your AI tool.
     Must: flag nulls, not crash on bad rows, produce output even if some rows fail.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    results = []
+    with open(input_path, encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                results.append(classify_complaint(row))
+            except Exception as exc:
+                results.append({
+                    "complaint_id": str(row.get("complaint_id", "UNKNOWN")).strip(),
+                    "category": "Other",
+                    "priority": "Standard",
+                    "reason": f"Classification failed on this row: {exc}",
+                    "flag": "NEEDS_REVIEW",
+                })
+
+    with open(output_path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["complaint_id", "category", "priority", "reason", "flag"])
+        writer.writeheader()
+        writer.writerows(results)
 
 
 if __name__ == "__main__":

--- a/uc-0a/results_ahmedabad.csv
+++ b/uc-0a/results_ahmedabad.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+AM-202401,Heat Hazard,Standard,"The description cites 'melting', 'tarmac', so category is Heat Hazard, priority is Standard because no severity keyword is cited.",
+AM-202402,Heat Hazard,Standard,"The description cites 'temperature', so category is Heat Hazard, priority is Standard because no severity keyword is cited.",
+AM-202405,Other,Standard,"The description cites no known category keyword, so category is Other, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW
+AM-202406,Heat Hazard,Standard,"The description cites 'heat', 'heatwave', so category is Heat Hazard, priority is Standard because no severity keyword is cited.",
+AM-202407,Road Damage,Urgent,"The description cites 'paving', 'upturned', so category is Road Damage, priority is Urgent because it cites 'child'.",
+AM-202410,Pothole,Standard,"The description cites 'pothole', so category is Pothole, priority is Standard because no severity keyword is cited.",
+AM-202414,Streetlight,Standard,"The description cites 'unlit', so category is Streetlight, priority is Standard because no severity keyword is cited.",
+AM-202417,Waste,Standard,"The description cites 'waste', 'heritage', so category is Waste, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW
+AM-202421,Noise,Low,"The description cites 'music', so category is Noise, priority is Low because no severity keyword is cited and the issue is a minor nuisance.",
+AM-202424,Road Damage,Standard,"The description cites 'road surface', so category is Road Damage, priority is Standard because no severity keyword is cited.",
+AM-202429,Heat Hazard,Standard,"The description cites 'temperature', so category is Heat Hazard, priority is Standard because no severity keyword is cited.",
+AM-202431,Heritage Damage,Standard,"The description cites 'heritage', so category is Heritage Damage, priority is Standard because no severity keyword is cited.",
+AM-202435,Heat Hazard,Standard,"The description cites 'heat', so category is Heat Hazard, priority is Standard because no severity keyword is cited.",
+AM-202444,Waste,Standard,"The description cites 'waste', 'bins', 'bin', so category is Waste, priority is Standard because no severity keyword is cited.",
+AM-202445,Other,Standard,"The description cites no known category keyword, so category is Other, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW

--- a/uc-0a/results_hyderabad.csv
+++ b/uc-0a/results_hyderabad.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+GH-202401,Flooding,Urgent,"The description cites 'flood', so category is Flooding, priority is Urgent because it cites 'ambulance'.",
+GH-202402,Flooding,Standard,"The description cites 'flood', 'drain ... blocked', so category is Flooding, priority is Standard because no severity keyword is cited.",
+GH-202406,Drain Blockage,Standard,"The description cites 'drain ... blocked', so category is Drain Blockage, priority is Standard because no severity keyword is cited.",
+GH-202407,Drain Blockage,Standard,"The description cites 'drain blocked', so category is Drain Blockage, priority is Standard because no severity keyword is cited.",
+GH-202410,Pothole,Standard,"The description cites 'pothole', so category is Pothole, priority is Standard because no severity keyword is cited.",
+GH-202411,Pothole,Urgent,"The description cites 'pothole', so category is Pothole, priority is Urgent because it cites 'hospital'.",
+GH-202412,Pothole,Urgent,"The description cites 'pothole', so category is Pothole, priority is Urgent because it cites 'school'.",
+GH-202417,Waste,Standard,"The description cites 'garbage', 'waste', 'heritage', so category is Waste, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW
+GH-202420,Noise,Low,"The description cites 'drilling', so category is Noise, priority is Low because no severity keyword is cited and the issue is a minor nuisance.",
+GH-202422,Road Damage,Urgent,"The description cites 'collapsed', 'crater', so category is Road Damage, priority is Urgent because it cites 'collapse'.",
+GH-202424,Flooding,Standard,"The description cites 'flood', 'band', so category is Flooding, priority is Standard because no severity keyword is cited.",
+GH-202428,Waste,Standard,"The description cites 'waste', so category is Waste, priority is Standard because no severity keyword is cited.",
+GH-202432,Noise,Low,"The description cites 'idling', so category is Noise, priority is Low because no severity keyword is cited and the issue is a minor nuisance.",
+GH-202448,Flooding,Standard,"The description cites 'flood', 'drain blocked', so category is Flooding, priority is Standard because no severity keyword is cited.",
+GH-202438,Flooding,Standard,"The description cites 'rainwater', so category is Flooding, priority is Standard because no severity keyword is cited.",

--- a/uc-0a/results_kolkata.csv
+++ b/uc-0a/results_kolkata.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+KM-202401,Streetlight,Standard,"The description cites 'lamp', 'heritage', so category is Streetlight, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW
+KM-202402,Road Damage,Standard,"The description cites 'cobblestone', 'historic', so category is Road Damage, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW
+KM-202405,Noise,Low,"The description cites 'band', so category is Noise, priority is Low because no severity keyword is cited and the issue is a minor nuisance.",
+KM-202409,Pothole,Standard,"The description cites 'pothole', so category is Pothole, priority is Standard because no severity keyword is cited.",
+KM-202410,Pothole,Standard,"The description cites 'pothole', so category is Pothole, priority is Standard because no severity keyword is cited.",
+KM-202411,Pothole,Standard,"The description cites 'pothole', 'rainwater', so category is Pothole, priority is Standard because no severity keyword is cited.",
+KM-202415,Drain Blockage,Standard,"The description cites 'draining', so category is Drain Blockage, priority is Standard because no severity keyword is cited.",
+KM-202418,Waste,Standard,"The description cites 'waste', so category is Waste, priority is Standard because no severity keyword is cited.",
+KM-202421,Road Damage,Urgent,"The description cites 'sinking', 'footpath', so category is Road Damage, priority is Urgent because it cites 'hospital', 'fell'.",
+KM-202422,Road Damage,Standard,"The description cites 'road surface', so category is Road Damage, priority is Standard because no severity keyword is cited.",
+KM-202426,Heritage Damage,Standard,"The description cites 'heritage', so category is Heritage Damage, priority is Standard because no severity keyword is cited.",
+KM-202430,Road Damage,Standard,"The description cites 'subsided', so category is Road Damage, priority is Standard because no severity keyword is cited.",
+KM-202434,Road Damage,Standard,"The description cites 'paving', 'heritage', so category is Road Damage, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW
+KM-202436,Streetlight,Standard,"The description cites 'dark', so category is Streetlight, priority is Standard because no severity keyword is cited.",
+KM-202438,Heritage Damage,Standard,"The description cites 'heritage', so category is Heritage Damage, priority is Standard because no severity keyword is cited.",

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+PM-202401,Pothole,Standard,"The description cites 'pothole', so category is Pothole, priority is Standard because no severity keyword is cited.",
+PM-202402,Pothole,Urgent,"The description cites 'pothole', so category is Pothole, priority is Urgent because it cites 'child', 'school'.",
+PM-202406,Flooding,Standard,"The description cites 'flood', so category is Flooding, priority is Standard because no severity keyword is cited.",
+PM-202408,Flooding,Standard,"The description cites 'flood', 'standing in water', 'drain blocked', so category is Flooding, priority is Standard because no severity keyword is cited.",
+PM-202410,Streetlight,Standard,"The description cites 'streetlight', 'lights out', 'dark', so category is Streetlight, priority is Standard because no severity keyword is cited.",
+PM-202411,Streetlight,Urgent,"The description cites 'streetlight', 'flickering', so category is Streetlight, priority is Urgent because it cites 'hazard'.",
+PM-202413,Waste,Low,"The description cites 'garbage', 'bins', 'bin', so category is Waste, priority is Low because no severity keyword is cited and the issue is a minor nuisance.",
+PM-202418,Noise,Low,"The description cites 'music', so category is Noise, priority is Low because no severity keyword is cited and the issue is a minor nuisance.",
+PM-202419,Road Damage,Standard,"The description cites 'cracked', 'sinking', 'road surface', so category is Road Damage, priority is Standard because no severity keyword is cited.",
+PM-202420,Pothole,Urgent,"The description cites 'manhole', so category is Pothole, priority is Urgent because it cites 'injury'.",
+PM-202427,Flooding,Standard,"The description cites 'flood', so category is Flooding, priority is Standard because no severity keyword is cited.",
+PM-202428,Waste,Standard,"The description cites 'dead animal', so category is Waste, priority is Standard because no severity keyword is cited.",
+PM-202430,Streetlight,Standard,"The description cites 'lights out', 'dark', 'heritage', so category is Streetlight, priority is Standard because no severity keyword is cited, and flag is NEEDS_REVIEW because it maps to multiple categories with comparable confidence.",NEEDS_REVIEW
+PM-202433,Waste,Standard,"The description cites 'waste', 'dumped', so category is Waste, priority is Standard because no severity keyword is cited.",
+PM-202446,Road Damage,Urgent,"The description cites 'footpath', 'tiles', 'upturned', so category is Road Damage, priority is Urgent because it cites 'fell'.",

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,37 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0A Complaint Classifier
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: >
+      Classify one complaint row into a schema-compliant 4-field output
+      (category, priority, reason, flag) without adding categories or guessing facts.
+    input: >
+      One complaint row as a dict with at least: complaint_id, description, ward,
+      location, days_open. Rows may contain nulls in any field.
+    output: >
+      A dict with exactly five keys: complaint_id (preserved), category (one of:
+      Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage,
+      Heat Hazard, Drain Blockage, Other), priority (Urgent, Standard, or Low),
+      reason (single sentence citing words from the description), flag
+      (NEEDS_REVIEW or blank string).
+    error_handling: >
+      If the description is null, empty, or cannot be matched to any allowed
+      category, output category "Other" with flag "NEEDS_REVIEW" rather than
+      inventing a category. If a severity keyword is present, priority must be
+      Urgent regardless of other signals.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: >
+      Read the input CSV, apply classify_complaint to every row, and write the
+      results CSV with the same complaint_id order as the input.
+    input: >
+      Input CSV path (test_[city].csv) and output CSV path (results_[city].csv).
+      Input has a header row and one row per complaint.
+    output: >
+      A CSV written to output_path with a header row and columns: complaint_id,
+      category, priority, reason, flag. One output row per input row.
+    error_handling: >
+      Never crash on a bad row: classify what can be classified, write
+      category "Other", priority "Standard", and flag "NEEDS_REVIEW" for any row
+      that fails, and always write a complete output file even if some rows fail.
+      Nulls in non-essential fields are allowed.


### PR DESCRIPTION
…and false confidence on ambiguity: naive prompt allowed variable categories and skipped reasons → added RICE-based agents.md and skills.md plus rule-based classifier.py enforcing the exact 10-category schema, severity-keyword Urgent rule, Low for minor nuisances, cited single-sentence reasons, and NEEDS_REVIEW on ambiguity