### PR TITLE
UC-0A Fix taxonomy drift, severity blindness, missing justification, …

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,28 +1,16 @@
 # agents.md — UC-0A Complaint Classifier
 
 role: >
-  An agent that classifies a single citizen complaint into exactly one category and one
-  priority level from a fixed enum. Its boundary ends at producing the classification row:
-  category, priority, reason, and flag. It does not decide policy, does not edit the input
-  data, and does not invent new categories.
+  A deterministic complaint classification agent that reads citizen complaint CSV files and assigns each row to one of ten allowed categories, one of three allowed priorities, a one-sentence reason citing specific words from the description, and an optional NEEDS_REVIEW flag for genuinely ambiguous cases.
 
 intent: >
-  A correct output is a row where category is one of exactly 10 allowed strings, priority
-  is Urgent whenever any severity keyword appears in the description, reason is a single
-  sentence quoting specific words from the description, and flag is NEEDS_REVIEW if and
-  only if the category cannot be determined from the description alone. Every output row
-  must be verifiable against the input row without external knowledge.
+  Produce a results CSV where every row has a valid complaint_id, an exact allowed category string, a valid priority, a one-sentence reason citing specific wording from the original description, and NEEDS_REVIEW flagged only when the category is genuinely ambiguous. No row may crash the pipeline; blank or malformed rows must be handled safely.
 
 context: >
-  Allowed to use: the complaint's description, location, and ward from the input row.
-  Allowed to use: the severity keyword list below.
-  Excluded: any assumption about the reporter, any information not present in the row,
-  any category not in the allowed enum, and any guess about intent behind the words.
+  The agent may only use the description column to classify. It must not hallucinate sub-categories or vary category names across rows for the same type of complaint. Allowed categories are: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other. Allowed priorities are: Urgent, Standard, Low. Severity keywords that force Urgent: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse.
 
 enforcement:
-  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other. No variations, no sub-categories, no renamed values."
-  - "Priority must be Urgent if the description contains any of: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse. Urgent wins over Standard/Low; no other signal may downgrade it."
-  - "Every output row must include a reason field: exactly one sentence that quotes specific words from the description. A reason with no quoted words from the description is invalid."
-  - "If no severity keyword is present, priority must be Standard unless the complaint is non-actionable cosmetic (e.g. dead animal removal) which may be Low; priority must never be chosen at random."
-  - "flag must be exactly NEEDS_REVIEW (or left blank). Set NEEDS_REVIEW only when the description maps to more than one allowed category with no way to decide from the description alone; otherwise leave blank."
-  - "Refusal condition: if the description cannot be mapped to any of the 10 allowed categories, output category: Other, priority: Standard, and flag: NEEDS_REVIEW. Never invent a category."
+  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other — no variations or abbreviations"
+  - "Priority must be Urgent if any severity keyword (injury, child, school, hospital, ambulance, fire, hazard, fell, collapse) appears in the description; otherwise Standard or Low"
+  - "Every output row must include a reason field that is exactly one sentence citing specific words from the complaint description"
+  - "If category cannot be determined from the description alone, output category: Other and flag: NEEDS_REVIEW"

--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,28 @@
 # agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  An agent that classifies a single citizen complaint into exactly one category and one
+  priority level from a fixed enum. Its boundary ends at producing the classification row:
+  category, priority, reason, and flag. It does not decide policy, does not edit the input
+  data, and does not invent new categories.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a row where category is one of exactly 10 allowed strings, priority
+  is Urgent whenever any severity keyword appears in the description, reason is a single
+  sentence quoting specific words from the description, and flag is NEEDS_REVIEW if and
+  only if the category cannot be determined from the description alone. Every output row
+  must be verifiable against the input row without external knowledge.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  Allowed to use: the complaint's description, location, and ward from the input row.
+  Allowed to use: the severity keyword list below.
+  Excluded: any assumption about the reporter, any information not present in the row,
+  any category not in the allowed enum, and any guess about intent behind the words.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other. No variations, no sub-categories, no renamed values."
+  - "Priority must be Urgent if the description contains any of: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse. Urgent wins over Standard/Low; no other signal may downgrade it."
+  - "Every output row must include a reason field: exactly one sentence that quotes specific words from the description. A reason with no quoted words from the description is invalid."
+  - "If no severity keyword is present, priority must be Standard unless the complaint is non-actionable cosmetic (e.g. dead animal removal) which may be Low; priority must never be chosen at random."
+  - "flag must be exactly NEEDS_REVIEW (or left blank). Set NEEDS_REVIEW only when the description maps to more than one allowed category with no way to decide from the description alone; otherwise leave blank."
+  - "Refusal condition: if the description cannot be mapped to any of the 10 allowed categories, output category: Other, priority: Standard, and flag: NEEDS_REVIEW. Never invent a category."

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,207 +1,120 @@
-"""
-UC-0A — Complaint Classifier.
-
-Implements the two skills from skills.md (classify_complaint, batch_classify)
-under the enforcement rules in agents.md:
-  - category is exactly one of the 10 allowed strings (never a variation)
-  - priority is Urgent iff a severity keyword appears in the description
-  - reason is exactly one sentence quoting specific words from the description
-  - flag is NEEDS_REVIEW iff the category cannot be decided from the
-    description alone (multiple categories match or none match)
-  - unmappable descriptions become category: Other, flag: NEEDS_REVIEW
-"""
+"""UC-0A — Complaint Classifier"""
 import argparse
 import csv
 import re
 
-ALLOWED_CATEGORIES = (
+ALLOWED_CATEGORIES = frozenset([
     "Pothole", "Flooding", "Streetlight", "Waste", "Noise",
     "Road Damage", "Heritage Damage", "Heat Hazard", "Drain Blockage", "Other",
-)
-
-SEVERITY_KEYWORDS = (
+])
+ALLOWED_PRIORITIES = frozenset(["Urgent", "Standard", "Low"])
+SEVERITY_KEYWORDS = frozenset([
     "injury", "child", "school", "hospital", "ambulance", "fire",
     "hazard", "fell", "collapse",
-)
+])
 
-_CATEGORY_PATTERNS = {
-    "Pothole": (r"\bpotholes?\b",),
-    "Flooding": (
-        r"\bflood(?:ed|s)?\b", r"knee[- ]deep", r"standing in water",
-        r"waterlog", r"submerg", r"inundat", r"channel rainwater",
-    ),
-    "Streetlight": (
-        r"streetlight", r"street light", r"lights? out", r"unlit",
-        r"\bdark(?:ness)?\b", r"\blamp", r"flicker", r"substation",
-        r"wiring theft",
-    ),
-    "Waste": (
-        r"\bgarbage\b", r"\bwaste\b", r"\btrash\b", r"dead animal",
-        r"\bbins?\b", r"\brubbish\b",
-    ),
-    "Noise": (
-        r"\bnoise\b", r"\bmusic\b", r"\bband\b", r"\bamplifier",
-        r"\bdrilling\b", r"\bidling\b", r"\bloud\b",
-    ),
-    "Road Damage": (
-        r"\bmanhole\b", r"\bfootpath\b", r"upturned paving",
-        r"\bcobblestone", r"\bcrater\b", r"\bcracked\b",
-        r"\bsinking\b", r"\bbuckled\b", r"\bsubsid(?:ed|ence)\b",
-        r"road collapsed",
-        r"road surface (?:cracked|sinking|buckled|subsided)",
-        r"tiles?\s+(?:broken|upturned)",
-    ),
-    "Heat Hazard": (
-        r"\bheat", r"\bmelting\b", r"\bbubbling\b",
-        r"\bunbearable\b", r"\bburn", r"full sun",
-        r"\btemperature", r"\b°c\b",
-    ),
-    "Drain Blockage": (r"\bdrain",),
+GENERIC_KEYWORDS = {
+    "Pothole": ["pothole", "potholes"],
+    "Flooding": ["flood", "flooded", "rainwater", "waterlogging", "water accumulation", "knee-deep"],
+    "Streetlight": ["streetlight"],
+    "Waste": ["garbage", "waste", "rubbish", "dumped", "not cleared", "not removed", "overflow"],
+    "Noise": ["music", "noise", "loud", "drilling"],
+    "Road Damage": ["footpath", "cracked", "sinking", "broken", "tiles", "manhole", "collapsed", "crater"],
+    "Heritage Damage": ["heritage"],
+    "Heat Hazard": ["heat", "temperature"],
+    "Drain Blockage": ["drain", "blocked", "drainage"],
 }
 
-_HERITAGE_WORDS = ("heritage", "historic", "ancient", "museum")
-_HERITAGE_DAMAGE_WORDS = (
-    "knocked over", "knocked", "broken", "defaced", "not replaced",
-    "subsidence", "subsided", "damaged", "damage",
-    "cracked", "buckled",
-)
 
-_LOW_PATTERNS = (r"dead animal", r"grass dying", r"dying in heatwave")
+def _classify_category(description: str) -> str:
+    desc_lower = description.lower()
 
-_COMPILED = {
-    cat: [re.compile(p, re.IGNORECASE) for p in pats]
-    for cat, pats in _CATEGORY_PATTERNS.items()
-}
-_LOW_COMPILED = [re.compile(p, re.IGNORECASE) for p in _LOW_PATTERNS]
+    matched = set()
+    for cat, keywords in GENERIC_KEYWORDS.items():
+        for kw in keywords:
+            if kw in desc_lower:
+                matched.add(cat)
+                break
 
+    if len(matched) == 0:
+        return "Other"
+    if len(matched) == 1:
+        return next(iter(matched))
 
-def _first_matches(text: str) -> dict:
-    """Earliest match per category -> {category: (quoted_text, position)}."""
-    hits = {}
-    lower = text.lower()
-    for category, patterns in _COMPILED.items():
-        best = None
-        for pattern in patterns:
-            m = pattern.search(text)
-            if m and (best is None or m.start() < best[1]):
-                best = (m.group(0), m.start())
-        if best:
-            hits[category] = best
+    matched_list = sorted(matched)
 
-    heritage_word = next((w for w in _HERITAGE_WORDS if w in lower), None)
-    damage_word = next((w for w in _HERITAGE_DAMAGE_WORDS if w in lower), None)
-    if heritage_word and damage_word:
-        pos = lower.find(heritage_word)
-        quote = text[pos:pos + len(heritage_word)]
-        if "Heritage Damage" not in hits or pos < hits["Heritage Damage"][1]:
-            hits["Heritage Damage"] = (quote, pos)
-    return hits
+    if "Heritage Damage" in matched and "Waste" in matched:
+        matched.discard("Waste")
+
+    if {"Drain Blockage", "Flooding"}.issubset(matched):
+        flood_pos = min(desc_lower.find(kw) for kw in ["flood", "flooded"] if kw in desc_lower)
+        drain_pos = min(desc_lower.find(kw) for kw in ["drain", "blocked"] if kw in desc_lower)
+        if flood_pos < drain_pos:
+            matched.discard("Drain Blockage")
+        else:
+            matched.discard("Flooding")
+
+    if len(matched) == 1:
+        return next(iter(matched))
+
+    return "Other"
 
 
-def _priority(description: str) -> str:
-    lower = description.lower()
-    if any(k in lower for k in SEVERITY_KEYWORDS):
-        return "Urgent"
-    if any(p.search(description) for p in _LOW_COMPILED):
-        return "Low"
-    return "Standard"
-
-
-def _quote_phrase(description: str) -> str:
-    text = description.strip()
-    end = text.find(".")
-    if end != -1:
-        text = text[:end]
-    text = text.strip()
-    if len(text) > 48:
-        text = text[:45].rstrip() + "..."
-    return text
+def _has_severity(text: str) -> bool:
+    text_lower = text.lower()
+    return any(kw in text_lower for kw in SEVERITY_KEYWORDS)
 
 
 def classify_complaint(row: dict) -> dict:
-    """Classify a single complaint row -> complaint_id, category, priority, reason, flag."""
-    if not isinstance(row, dict):
-        return {
-            "complaint_id": "", "category": "Other", "priority": "Standard",
-            "reason": "No description was provided, so the complaint is flagged NEEDS_REVIEW.",
-            "flag": "NEEDS_REVIEW",
-        }
+    complaint_id = row.get("complaint_id", "")
+    description = row.get("description", "") or ""
 
-    complaint_id = row.get("complaint_id") or ""
-    description = row.get("description")
+    category = _classify_category(description)
+    priority = "Urgent" if _has_severity(description) else "Standard"
 
-    if description is None or not str(description).strip():
-        return {
-            "complaint_id": complaint_id, "category": "Other", "priority": "Standard",
-            "reason": "No description was provided, so the complaint is flagged NEEDS_REVIEW.",
-            "flag": "NEEDS_REVIEW",
-        }
-    if not isinstance(description, str):
-        description = str(description)
-
-    hits = _first_matches(description)
-
-    if not hits:
-        return {
-            "complaint_id": complaint_id, "category": "Other",
-            "priority": _priority(description),
-            "reason": (f'The description "{_quote_phrase(description)}" maps to no allowed '
-                       "category, so it is flagged NEEDS_REVIEW."),
-            "flag": "NEEDS_REVIEW",
-        }
-
-    categories = sorted(hits, key=lambda c: hits[c][1])
-
-    if len(categories) == 1:
-        category = categories[0]
-        reason = f'The description mentions "{hits[category][0]}", so this is classified as {category}.'
-        return {
-            "complaint_id": complaint_id, "category": category,
-            "priority": _priority(description), "reason": reason, "flag": "",
-        }
-
-    category = categories[0]
-    quotes = [hits[c][0] for c in categories[:2]]
-    if len(categories) == 2:
-        reason = (f'The description mentions both "{quotes[0]}" and "{quotes[1]}", so the '
-                  "category cannot be decided from the description alone and is flagged NEEDS_REVIEW.")
+    if description.strip():
+        sentences = [s.strip() for s in re.split(r"[.!?]+", description) if s.strip()]
+        reason_sentence = sentences[0] + "." if sentences else description.strip()
+        if not reason_sentence.endswith("."):
+            reason_sentence += "."
     else:
-        reason = (f'The description mentions "{quotes[0]}" and other categories, so the '
-                  "category cannot be decided from the description alone and is flagged NEEDS_REVIEW.")
+        reason_sentence = "No description provided."
+
+    flag = "NEEDS_REVIEW" if category == "Other" else ""
+
     return {
-        "complaint_id": complaint_id, "category": category,
-        "priority": _priority(description), "reason": reason, "flag": "NEEDS_REVIEW",
+        "complaint_id": complaint_id,
+        "category": category,
+        "priority": priority,
+        "reason": reason_sentence,
+        "flag": flag,
     }
 
 
 def batch_classify(input_path: str, output_path: str):
-    """Read input CSV, classify each row, write results CSV, print the row count."""
-    rows = []
-    with open(input_path, newline="", encoding="utf-8-sig") as f:
-        reader = csv.DictReader(f)
-        for i, row in enumerate(reader):
-            if row is None:
-                continue
-            try:
-                out = classify_complaint(row)
-            except Exception:
-                out = {
-                    "complaint_id": row.get("complaint_id") or str(i + 1),
-                    "category": "Other", "priority": "Standard",
-                    "reason": "The row could not be processed, so it is flagged NEEDS_REVIEW.",
-                    "flag": "NEEDS_REVIEW",
-                }
-            if not out.get("complaint_id"):
-                out["complaint_id"] = str(i + 1)
-            rows.append(out)
+    with open(input_path, newline="", encoding="utf-8") as infile:
+        reader = csv.DictReader(infile)
+        rows = list(reader)
 
-    fieldnames = ["complaint_id", "category", "priority", "reason", "flag"]
-    with open(output_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
+    results = []
+    for row in rows:
+        try:
+            result = classify_complaint(row)
+            results.append(result)
+        except Exception:
+            results.append({
+                "complaint_id": row.get("complaint_id", ""),
+                "category": "Other",
+                "priority": "Standard",
+                "reason": "Could not classify row.",
+                "flag": "NEEDS_REVIEW",
+            })
+
+    out_fields = ["complaint_id", "category", "priority", "reason", "flag"]
+    with open(output_path, "w", newline="", encoding="utf-8") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=out_fields)
         writer.writeheader()
-        writer.writerows(rows)
-
-    print(f"Classified {len(rows)} rows.")
+        writer.writerows(results)
 
 
 if __name__ == "__main__":

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,34 +1,212 @@
 """
-UC-0A — Complaint Classifier
-Starter file. Build this using the RICE → agents.md → skills.md → CRAFT workflow.
+UC-0A — Complaint Classifier.
+
+Implements the two skills from skills.md (classify_complaint, batch_classify)
+under the enforcement rules in agents.md:
+  - category is exactly one of the 10 allowed strings (never a variation)
+  - priority is Urgent iff a severity keyword appears in the description
+  - reason is exactly one sentence quoting specific words from the description
+  - flag is NEEDS_REVIEW iff the category cannot be decided from the
+    description alone (multiple categories match or none match)
+  - unmappable descriptions become category: Other, flag: NEEDS_REVIEW
 """
 import argparse
 import csv
+import re
+
+ALLOWED_CATEGORIES = (
+    "Pothole", "Flooding", "Streetlight", "Waste", "Noise",
+    "Road Damage", "Heritage Damage", "Heat Hazard", "Drain Blockage", "Other",
+)
+
+SEVERITY_KEYWORDS = (
+    "injury", "child", "school", "hospital", "ambulance", "fire",
+    "hazard", "fell", "collapse",
+)
+
+_CATEGORY_PATTERNS = {
+    "Pothole": (r"\bpotholes?\b",),
+    "Flooding": (
+        r"\bflood(?:ed|s)?\b", r"knee[- ]deep", r"standing in water",
+        r"waterlog", r"submerg", r"inundat", r"channel rainwater",
+    ),
+    "Streetlight": (
+        r"streetlight", r"street light", r"lights? out", r"unlit",
+        r"\bdark(?:ness)?\b", r"\blamp", r"flicker", r"substation",
+        r"wiring theft",
+    ),
+    "Waste": (
+        r"\bgarbage\b", r"\bwaste\b", r"\btrash\b", r"dead animal",
+        r"\bbins?\b", r"\brubbish\b",
+    ),
+    "Noise": (
+        r"\bnoise\b", r"\bmusic\b", r"\bband\b", r"\bamplifier",
+        r"\bdrilling\b", r"\bidling\b", r"\bloud\b",
+    ),
+    "Road Damage": (
+        r"\bmanhole\b", r"\bfootpath\b", r"upturned paving",
+        r"\bcobblestone", r"\bcrater\b", r"\bcracked\b",
+        r"\bsinking\b", r"\bbuckled\b", r"\bsubsid(?:ed|ence)\b",
+        r"road collapsed",
+        r"road surface (?:cracked|sinking|buckled|subsided)",
+        r"tiles?\s+(?:broken|upturned)",
+    ),
+    "Heat Hazard": (
+        r"\bheat", r"\bmelting\b", r"\bbubbling\b",
+        r"\bunbearable\b", r"\bburn", r"full sun",
+        r"\btemperature", r"\b°c\b",
+    ),
+    "Drain Blockage": (r"\bdrain",),
+}
+
+_HERITAGE_WORDS = ("heritage", "historic", "ancient", "museum")
+_HERITAGE_DAMAGE_WORDS = (
+    "knocked over", "knocked", "broken", "defaced", "not replaced",
+    "subsidence", "subsided", "damaged", "damage",
+    "cracked", "buckled",
+)
+
+_LOW_PATTERNS = (r"dead animal", r"grass dying", r"dying in heatwave")
+
+_COMPILED = {
+    cat: [re.compile(p, re.IGNORECASE) for p in pats]
+    for cat, pats in _CATEGORY_PATTERNS.items()
+}
+_LOW_COMPILED = [re.compile(p, re.IGNORECASE) for p in _LOW_PATTERNS]
+
+
+def _first_matches(text: str) -> dict:
+    """Earliest match per category -> {category: (quoted_text, position)}."""
+    hits = {}
+    lower = text.lower()
+    for category, patterns in _COMPILED.items():
+        best = None
+        for pattern in patterns:
+            m = pattern.search(text)
+            if m and (best is None or m.start() < best[1]):
+                best = (m.group(0), m.start())
+        if best:
+            hits[category] = best
+
+    heritage_word = next((w for w in _HERITAGE_WORDS if w in lower), None)
+    damage_word = next((w for w in _HERITAGE_DAMAGE_WORDS if w in lower), None)
+    if heritage_word and damage_word:
+        pos = lower.find(heritage_word)
+        quote = text[pos:pos + len(heritage_word)]
+        if "Heritage Damage" not in hits or pos < hits["Heritage Damage"][1]:
+            hits["Heritage Damage"] = (quote, pos)
+    return hits
+
+
+def _priority(description: str) -> str:
+    lower = description.lower()
+    if any(k in lower for k in SEVERITY_KEYWORDS):
+        return "Urgent"
+    if any(p.search(description) for p in _LOW_COMPILED):
+        return "Low"
+    return "Standard"
+
+
+def _quote_phrase(description: str) -> str:
+    text = description.strip()
+    end = text.find(".")
+    if end != -1:
+        text = text[:end]
+    text = text.strip()
+    if len(text) > 48:
+        text = text[:45].rstrip() + "..."
+    return text
+
 
 def classify_complaint(row: dict) -> dict:
-    """
-    Classify a single complaint row.
-    Returns: dict with keys: complaint_id, category, priority, reason, flag
-    
-    TODO: Build this using your AI tool guided by your agents.md and skills.md.
-    Your RICE enforcement rules must be reflected in this function's behaviour.
-    """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    """Classify a single complaint row -> complaint_id, category, priority, reason, flag."""
+    if not isinstance(row, dict):
+        return {
+            "complaint_id": "", "category": "Other", "priority": "Standard",
+            "reason": "No description was provided, so the complaint is flagged NEEDS_REVIEW.",
+            "flag": "NEEDS_REVIEW",
+        }
+
+    complaint_id = row.get("complaint_id") or ""
+    description = row.get("description")
+
+    if description is None or not str(description).strip():
+        return {
+            "complaint_id": complaint_id, "category": "Other", "priority": "Standard",
+            "reason": "No description was provided, so the complaint is flagged NEEDS_REVIEW.",
+            "flag": "NEEDS_REVIEW",
+        }
+    if not isinstance(description, str):
+        description = str(description)
+
+    hits = _first_matches(description)
+
+    if not hits:
+        return {
+            "complaint_id": complaint_id, "category": "Other",
+            "priority": _priority(description),
+            "reason": (f'The description "{_quote_phrase(description)}" maps to no allowed '
+                       "category, so it is flagged NEEDS_REVIEW."),
+            "flag": "NEEDS_REVIEW",
+        }
+
+    categories = sorted(hits, key=lambda c: hits[c][1])
+
+    if len(categories) == 1:
+        category = categories[0]
+        reason = f'The description mentions "{hits[category][0]}", so this is classified as {category}.'
+        return {
+            "complaint_id": complaint_id, "category": category,
+            "priority": _priority(description), "reason": reason, "flag": "",
+        }
+
+    category = categories[0]
+    quotes = [hits[c][0] for c in categories[:2]]
+    if len(categories) == 2:
+        reason = (f'The description mentions both "{quotes[0]}" and "{quotes[1]}", so the '
+                  "category cannot be decided from the description alone and is flagged NEEDS_REVIEW.")
+    else:
+        reason = (f'The description mentions "{quotes[0]}" and other categories, so the '
+                  "category cannot be decided from the description alone and is flagged NEEDS_REVIEW.")
+    return {
+        "complaint_id": complaint_id, "category": category,
+        "priority": _priority(description), "reason": reason, "flag": "NEEDS_REVIEW",
+    }
 
 
 def batch_classify(input_path: str, output_path: str):
-    """
-    Read input CSV, classify each row, write results CSV.
-    
-    TODO: Build this using your AI tool.
-    Must: flag nulls, not crash on bad rows, produce output even if some rows fail.
-    """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    """Read input CSV, classify each row, write results CSV, print the row count."""
+    rows = []
+    with open(input_path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for i, row in enumerate(reader):
+            if row is None:
+                continue
+            try:
+                out = classify_complaint(row)
+            except Exception:
+                out = {
+                    "complaint_id": row.get("complaint_id") or str(i + 1),
+                    "category": "Other", "priority": "Standard",
+                    "reason": "The row could not be processed, so it is flagged NEEDS_REVIEW.",
+                    "flag": "NEEDS_REVIEW",
+                }
+            if not out.get("complaint_id"):
+                out["complaint_id"] = str(i + 1)
+            rows.append(out)
+
+    fieldnames = ["complaint_id", "category", "priority", "reason", "flag"]
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"Classified {len(rows)} rows.")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="UC-0A Complaint Classifier")
-    parser.add_argument("--input",  required=True, help="Path to test_[city].csv")
+    parser.add_argument("--input", required=True, help="Path to test_[city].csv")
     parser.add_argument("--output", required=True, help="Path to write results CSV")
     args = parser.parse_args()
     batch_classify(args.input, args.output)

--- a/uc-0a/results_ahmedabad.csv
+++ b/uc-0a/results_ahmedabad.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+AM-202401,Heat Hazard,Standard,"The description mentions ""melting"", so this is classified as Heat Hazard.",
+AM-202402,Heat Hazard,Standard,"The description mentions ""temperature"", so this is classified as Heat Hazard.",
+AM-202405,Other,Standard,"The description ""Dead trees with split branches"" maps to no allowed category, so it is flagged NEEDS_REVIEW.",NEEDS_REVIEW
+AM-202406,Heat Hazard,Low,"The description mentions ""heat"", so this is classified as Heat Hazard.",
+AM-202407,Road Damage,Urgent,"The description mentions ""upturned paving"", so this is classified as Road Damage.",
+AM-202410,Pothole,Standard,"The description mentions ""Pothole"", so this is classified as Pothole.",
+AM-202414,Streetlight,Standard,"The description mentions ""unlit"", so this is classified as Streetlight.",
+AM-202417,Waste,Standard,"The description mentions ""waste"", so this is classified as Waste.",
+AM-202421,Noise,Standard,"The description mentions ""music"", so this is classified as Noise.",
+AM-202424,Heat Hazard,Standard,"The description mentions ""bubbling"", so this is classified as Heat Hazard.",
+AM-202429,Heat Hazard,Standard,"The description mentions ""temperature"", so this is classified as Heat Hazard.",
+AM-202431,Road Damage,Standard,"The description mentions both ""subsidence"" and ""Heritage"", so the category cannot be decided from the description alone and is flagged NEEDS_REVIEW.",NEEDS_REVIEW
+AM-202435,Heat Hazard,Standard,"The description mentions ""heat"", so this is classified as Heat Hazard.",
+AM-202444,Waste,Standard,"The description mentions ""waste"", so this is classified as Waste.",
+AM-202445,Heat Hazard,Standard,"The description mentions ""full sun"", so this is classified as Heat Hazard.",

--- a/uc-0a/results_hyderabad.csv
+++ b/uc-0a/results_hyderabad.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+GH-202401,Flooding,Urgent,"The description mentions ""flooded"", so this is classified as Flooding.",
+GH-202402,Flooding,Standard,"The description mentions both ""flooded"" and ""Drain"", so the category cannot be decided from the description alone and is flagged NEEDS_REVIEW.",NEEDS_REVIEW
+GH-202406,Drain Blockage,Standard,"The description mentions ""drain"", so this is classified as Drain Blockage.",
+GH-202407,Drain Blockage,Standard,"The description mentions ""Drain"", so this is classified as Drain Blockage.",
+GH-202410,Pothole,Standard,"The description mentions ""Potholes"", so this is classified as Pothole.",
+GH-202411,Pothole,Urgent,"The description mentions ""Pothole"", so this is classified as Pothole.",
+GH-202412,Pothole,Urgent,"The description mentions ""potholes"", so this is classified as Pothole.",
+GH-202417,Waste,Standard,"The description mentions ""garbage"", so this is classified as Waste.",
+GH-202420,Noise,Standard,"The description mentions ""drilling"", so this is classified as Noise.",
+GH-202422,Road Damage,Urgent,"The description mentions ""Road collapsed"", so this is classified as Road Damage.",
+GH-202424,Flooding,Standard,"The description mentions ""floods"", so this is classified as Flooding.",
+GH-202428,Waste,Standard,"The description mentions ""waste"", so this is classified as Waste.",
+GH-202432,Noise,Standard,"The description mentions ""idling"", so this is classified as Noise.",
+GH-202448,Drain Blockage,Standard,"The description mentions ""drain"", so this is classified as Drain Blockage.",
+GH-202438,Flooding,Standard,"The description mentions ""channel rainwater"", so this is classified as Flooding.",

--- a/uc-0a/results_kolkata.csv
+++ b/uc-0a/results_kolkata.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+KM-202401,Heritage Damage,Standard,"The description mentions both ""Heritage"" and ""lamp"", so the category cannot be decided from the description alone and is flagged NEEDS_REVIEW.",NEEDS_REVIEW
+KM-202402,Heritage Damage,Standard,"The description mentions both ""Historic"" and ""cobblestone"", so the category cannot be decided from the description alone and is flagged NEEDS_REVIEW.",NEEDS_REVIEW
+KM-202405,Noise,Standard,"The description mentions ""band"", so this is classified as Noise.",
+KM-202409,Pothole,Standard,"The description mentions ""potholes"", so this is classified as Pothole.",
+KM-202410,Pothole,Standard,"The description mentions ""Pothole"", so this is classified as Pothole.",
+KM-202411,Pothole,Standard,"The description mentions ""pothole"", so this is classified as Pothole.",
+KM-202415,Drain Blockage,Standard,"The description mentions ""drain"", so this is classified as Drain Blockage.",
+KM-202418,Waste,Standard,"The description mentions ""waste"", so this is classified as Waste.",
+KM-202421,Road Damage,Urgent,"The description mentions ""Footpath"", so this is classified as Road Damage.",
+KM-202422,Road Damage,Standard,"The description mentions ""Road surface buckled"", so this is classified as Road Damage.",
+KM-202426,Heritage Damage,Standard,"The description mentions ""Heritage"", so this is classified as Heritage Damage.",
+KM-202430,Road Damage,Standard,"The description mentions ""subsided"", so this is classified as Road Damage.",
+KM-202434,Heritage Damage,Standard,"The description mentions ""heritage"", so this is classified as Heritage Damage.",
+KM-202436,Streetlight,Standard,"The description mentions ""substation"", so this is classified as Streetlight.",
+KM-202438,Noise,Standard,"The description mentions ""amplifier"", so this is classified as Noise.",

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+PM-202401,Pothole,Standard,"The description mentions ""pothole"", so this is classified as Pothole.",
+PM-202402,Pothole,Urgent,"The description mentions ""pothole"", so this is classified as Pothole.",
+PM-202406,Flooding,Standard,"The description mentions ""flooded"", so this is classified as Flooding.",
+PM-202408,Flooding,Standard,"The description mentions both ""flooded"" and ""Drain"", so the category cannot be decided from the description alone and is flagged NEEDS_REVIEW.",NEEDS_REVIEW
+PM-202410,Streetlight,Standard,"The description mentions ""streetlight"", so this is classified as Streetlight.",
+PM-202411,Streetlight,Urgent,"The description mentions ""Streetlight"", so this is classified as Streetlight.",
+PM-202413,Waste,Standard,"The description mentions ""garbage"", so this is classified as Waste.",
+PM-202418,Noise,Standard,"The description mentions ""music"", so this is classified as Noise.",
+PM-202419,Road Damage,Standard,"The description mentions ""Road surface cracked"", so this is classified as Road Damage.",
+PM-202420,Road Damage,Urgent,"The description mentions ""Manhole"", so this is classified as Road Damage.",
+PM-202427,Flooding,Standard,"The description mentions ""floods"", so this is classified as Flooding.",
+PM-202428,Waste,Low,"The description mentions ""Dead animal"", so this is classified as Waste.",
+PM-202430,Streetlight,Standard,"The description mentions ""lights out"", so this is classified as Streetlight.",
+PM-202433,Waste,Standard,"The description mentions ""waste"", so this is classified as Waste.",
+PM-202446,Road Damage,Urgent,"The description mentions ""Footpath"", so this is classified as Road Damage.",

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0A Complaint Classifier
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: Classifies one complaint row into category, priority, reason, and flag using the fixed enum and severity keyword rules.
+    input: A dict (one row from test_[city].csv) with at least the keys complaint_id and description.
+    output: A dict with keys complaint_id, category, priority, reason, flag. category is one of the 10 allowed strings; priority is Urgent/Standard/Low; reason quotes words from the description; flag is NEEDS_REVIEW or blank.
+    error_handling: If description is missing or empty, returns category: Other, priority: Standard, reason quoting that no description was provided, flag: NEEDS_REVIEW. Never raises on malformed input.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: Reads the input CSV, applies classify_complaint to every row, writes the results CSV with one output row per input row.
+    input: input_path (path to test_[city].csv) and output_path (path to write results_[city].csv).
+    output: Writes a CSV with columns complaint_id, category, priority, reason, flag; prints the total row count on completion.
+    error_handling: Flags rows with missing/blank description as NEEDS_REVIEW instead of crashing; continues on bad rows and always produces an output file even if some rows fail.

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,14 +1,14 @@
-# skills.md — UC-0A Complaint Classifier
+# skills.md
 
 skills:
   - name: classify_complaint
-    description: Classifies one complaint row into category, priority, reason, and flag using the fixed enum and severity keyword rules.
-    input: A dict (one row from test_[city].csv) with at least the keys complaint_id and description.
-    output: A dict with keys complaint_id, category, priority, reason, flag. category is one of the 10 allowed strings; priority is Urgent/Standard/Low; reason quotes words from the description; flag is NEEDS_REVIEW or blank.
-    error_handling: If description is missing or empty, returns category: Other, priority: Standard, reason quoting that no description was provided, flag: NEEDS_REVIEW. Never raises on malformed input.
+    description: Classifies a single complaint row into category, priority, reason, and flag using deterministic keyword matching against the allowed schema.
+    input: A dict representing one CSV row with keys complaint_id and description.
+    output: A dict with keys complaint_id, category, priority, reason, flag.
+    error_handling: Returns category Other and flag NEEDS_REVIEW if description is blank or no category keyword matches; handles missing keys gracefully.
 
   - name: batch_classify
-    description: Reads the input CSV, applies classify_complaint to every row, writes the results CSV with one output row per input row.
-    input: input_path (path to test_[city].csv) and output_path (path to write results_[city].csv).
-    output: Writes a CSV with columns complaint_id, category, priority, reason, flag; prints the total row count on completion.
-    error_handling: Flags rows with missing/blank description as NEEDS_REVIEW instead of crashing; continues on bad rows and always produces an output file even if some rows fail.
+    description: Reads an input CSV, applies classify_complaint to every row, and writes the results to an output CSV.
+    input: Input CSV file path and output CSV file path.
+    output: Writes a results CSV with columns complaint_id, category, priority, reason, flag.
+    error_handling: Skips rows that cannot be parsed, logs a warning, and still produces a valid output CSV even if some rows fail.


### PR DESCRIPTION
…hallucinated sub-categories, false confidence on ambiguity: the naive prompt yields varied category names, Urgent misses, no reason field, and over-confident flags on ambiguous rows → implemented agents.md enforcement rules + skills.md specs and a rule-based classifier.py that emits the exact 10-category enum, Urgent from severity keywords, one-sentence quoted reasons, and NEEDS_REVIEW only when the category is undecidable from the description alone