### PR TITLE
Participant/devi perumalsamy bangalore

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,31 @@
 # agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a civic complaint classification agent. You take a single citizen
+  complaint (free-text description plus any metadata) and assign it to a fixed
+  taxonomy with a priority level, a justification, and an ambiguity flag. Your
+  boundary is classification only: you do not summarise, rewrite, translate, or
+  invent details beyond what the description states.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a row containing exactly four fields — category, priority,
+  reason, flag — where: category is one of the ten allowed strings verbatim;
+  priority is one of Urgent, Standard, or Low; reason is a single sentence that
+  quotes specific words from the complaint description; and flag is either
+  NEEDS_REVIEW or blank. Correctness is verifiable by checking each field
+  against the allowed values below and confirming the reason cites the input.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the complaint description and any provided row metadata.
+  It must NOT use outside knowledge of the city, assume facts not stated, or
+  guess a category to appear confident. If the description does not clearly map
+  to one category, the correct action is to flag it — not to pick the closest
+  guess silently.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other. No vari/pluralised/reworded forms; string must match verbatim."
+  - "Priority must be set to Urgent if the description contains any severity keyword: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse. Match is case-insensitive on the word."
+  - "Every output row must include a reason field: one sentence that cites specific words copied from the description. A reason with no words from the input is invalid."
+  - "No sub-categories or new category names may be invented. If the complaint fits no allowed category, use category: Other."
+  - "If the category is genuinely ambiguous (fits two categories equally, or the description is too vague to decide), set flag: NEEDS_REVIEW rather than guessing confidently. Otherwise leave flag blank."
+  - "Do not output any field the schema does not define, and do not omit any of the four required fields."

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,29 +1,169 @@
 """
 UC-0A — Complaint Classifier
-Starter file. Build this using the RICE → agents.md → skills.md → CRAFT workflow.
+
+Built from the RICE contract in agents.md and the skill specs in skills.md.
+Deterministic, rule-based: no network/LLM calls, runs with only the stdlib so it
+works in any workshop environment.
+
+Enforcement encoded here (see agents.md):
+  - category is EXACTLY one of the ten allowed strings (taxonomy drift guard)
+  - priority is Urgent whenever a severity keyword appears (severity blindness guard)
+  - reason always cites specific words copied from the description
+  - no invented sub-categories; unmatched -> Other
+  - genuine ambiguity (0 matches, or a tie between categories) -> flag NEEDS_REVIEW
 """
 import argparse
 import csv
+import re
+
+# --- Fixed taxonomy: allowed category strings, verbatim (order = tie-break priority) ---
+ALLOWED_CATEGORIES = [
+    "Pothole", "Flooding", "Streetlight", "Waste", "Noise",
+    "Road Damage", "Heritage Damage", "Heat Hazard", "Drain Blockage", "Other",
+]
+
+# Keyword signals per category. Matched case-insensitively as whole words.
+CATEGORY_KEYWORDS = {
+    "Pothole":         ["pothole", "potholes"],
+    "Flooding":        ["flood", "flooding", "flooded", "waterlogging", "waterlogged", "inundated"],
+    "Streetlight":     ["streetlight", "street light", "street lamp", "lamp post", "lamppost", "light pole"],
+    "Waste":           ["garbage", "waste", "trash", "rubbish", "litter", "dump", "dumping", "sewage overflow"],
+    "Noise":           ["noise", "loud", "loudspeaker", "blaring", "honking", "disturbance"],
+    "Road Damage":     ["road damage", "cracked road", "broken road", "crumbling", "damaged road", "road surface", "crack"],
+    "Heritage Damage": ["heritage", "monument", "historic", "statue", "fort", "temple wall", "heritage site"],
+    "Heat Hazard":     ["heat", "heatwave", "heat wave", "no shade", "melting", "scorching"],
+    "Drain Blockage":  ["drain", "drainage", "blocked drain", "clogged", "sewer", "manhole", "gutter"],
+}
+
+# Severity keywords that MUST force Urgent (agents.md / README).
+# Inflections added so "children"/"injuries"/"collapsed" still trigger Urgent.
+SEVERITY_KEYWORDS = [
+    "injury", "injuries", "child", "children", "school", "schools",
+    "hospital", "ambulance", "fire", "hazard", "hazardous",
+    "fell", "collapse", "collapsed", "collapsing",
+]
+
+# Light signals for the Standard vs Low split (Urgent is decided separately).
+LOW_KEYWORDS = ["minor", "small", "cosmetic", "faded", "slightly", "occasional"]
+
+OUTPUT_FIELDS = ["complaint_id", "category", "priority", "reason", "flag"]
+
+
+def _found(keywords, text):
+    """
+    Return the list of keywords that appear in text as whole words, tolerating a
+    simple plural 's' (so "streetlights"/"floods"/"potholes" still match).
+    """
+    hits = []
+    for kw in keywords:
+        if re.search(r"\b" + re.escape(kw) + r"s?\b", text):
+            hits.append(kw)
+    return hits
+
 
 def classify_complaint(row: dict) -> dict:
     """
     Classify a single complaint row.
-    Returns: dict with keys: complaint_id, category, priority, reason, flag
-    
-    TODO: Build this using your AI tool guided by your agents.md and skills.md.
-    Your RICE enforcement rules must be reflected in this function's behaviour.
+    Returns a dict with keys: complaint_id, category, priority, reason, flag.
+    Reflects the enforcement rules in agents.md.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    cid = (row.get("complaint_id") or "").strip()
+    description = (row.get("description") or "").strip()
+
+    # Empty description -> cannot classify; flag for review (skills.md error_handling).
+    if not description:
+        return {
+            "complaint_id": cid,
+            "category": "Other",
+            "priority": "Standard",
+            "reason": "Description is empty, so no category could be determined from the text.",
+            "flag": "NEEDS_REVIEW",
+        }
+
+    text = description.lower()
+
+    # --- Category: score each allowed category by keyword hits ---
+    scores = {}
+    hits_by_cat = {}
+    for cat, kws in CATEGORY_KEYWORDS.items():
+        hits = _found(kws, text)
+        if hits:
+            scores[cat] = len(hits)
+            hits_by_cat[cat] = hits
+
+    flag = ""
+    if not scores:
+        # No allowed category fits -> Other, and flag as ambiguous.
+        category = "Other"
+        matched_words = []
+        flag = "NEEDS_REVIEW"
+    else:
+        top = max(scores.values())
+        winners = [c for c in ALLOWED_CATEGORIES if scores.get(c) == top]
+        category = winners[0]  # deterministic tie-break by taxonomy order
+        matched_words = hits_by_cat[category]
+        # Genuine ambiguity: two different categories tie on the top score.
+        if len(winners) > 1:
+            flag = "NEEDS_REVIEW"
+
+    # --- Priority: severity keywords force Urgent ---
+    severity_hits = _found(SEVERITY_KEYWORDS, text)
+    if severity_hits:
+        priority = "Urgent"
+    elif _found(LOW_KEYWORDS, text):
+        priority = "Low"
+    else:
+        priority = "Standard"
+
+    # --- Reason: must cite specific words from the description ---
+    cited = matched_words + severity_hits
+    if cited:
+        quoted = ", ".join(f'"{w}"' for w in dict.fromkeys(cited))  # dedupe, keep order
+        reason = f"Classified as {category} ({priority}) based on the words {quoted} in the description."
+    else:
+        # Category is Other with no keyword hits: cite the opening of the text itself.
+        snippet = " ".join(description.split()[:8])
+        reason = f'No taxonomy keyword matched; description reads "{snippet}...", so it is Other and needs review.'
+
+    return {
+        "complaint_id": cid,
+        "category": category,
+        "priority": priority,
+        "reason": reason,
+        "flag": flag,
+    }
 
 
 def batch_classify(input_path: str, output_path: str):
     """
     Read input CSV, classify each row, write results CSV.
-    
-    TODO: Build this using your AI tool.
-    Must: flag nulls, not crash on bad rows, produce output even if some rows fail.
+    Never crashes on a single bad row; always writes an output file.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    with open(input_path, newline="", encoding="utf-8-sig") as f_in:
+        rows = list(csv.DictReader(f_in))
+
+    results = []
+    ok, failed = 0, 0
+    for i, row in enumerate(rows):
+        try:
+            results.append(classify_complaint(row))
+            ok += 1
+        except Exception as exc:  # keep going; flag the row rather than dropping it
+            failed += 1
+            results.append({
+                "complaint_id": (row.get("complaint_id") or f"row_{i}").strip(),
+                "category": "Other",
+                "priority": "Standard",
+                "reason": f"Row could not be processed ({type(exc).__name__}); flagged for manual review.",
+                "flag": "NEEDS_REVIEW",
+            })
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f_out:
+        writer = csv.DictWriter(f_out, fieldnames=OUTPUT_FIELDS)
+        writer.writeheader()
+        writer.writerows(results)
+
+    print(f"Classified {ok} row(s), {failed} flagged on error, {len(results)} total.")
 
 
 if __name__ == "__main__":

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+PM-202401,Pothole,Standard,"Classified as Pothole (Standard) based on the words ""pothole"" in the description.",
+PM-202402,Pothole,Urgent,"Classified as Pothole (Urgent) based on the words ""pothole"", ""children"", ""school"" in the description.",
+PM-202406,Flooding,Standard,"Classified as Flooding (Standard) based on the words ""flooded"" in the description.",
+PM-202408,Flooding,Standard,"Classified as Flooding (Standard) based on the words ""flooded"" in the description.",NEEDS_REVIEW
+PM-202410,Streetlight,Standard,"Classified as Streetlight (Standard) based on the words ""streetlight"" in the description.",
+PM-202411,Streetlight,Urgent,"Classified as Streetlight (Urgent) based on the words ""streetlight"", ""hazard"" in the description.",
+PM-202413,Waste,Standard,"Classified as Waste (Standard) based on the words ""garbage"" in the description.",
+PM-202418,Other,Standard,"No taxonomy keyword matched; description reads ""Wedding venue playing music past midnight on weeknights...."", so it is Other and needs review.",NEEDS_REVIEW
+PM-202419,Road Damage,Standard,"Classified as Road Damage (Standard) based on the words ""road surface"" in the description.",
+PM-202420,Drain Blockage,Urgent,"Classified as Drain Blockage (Urgent) based on the words ""manhole"", ""injury"" in the description.",
+PM-202427,Flooding,Standard,"Classified as Flooding (Standard) based on the words ""flood"" in the description.",
+PM-202428,Other,Standard,"No taxonomy keyword matched; description reads ""Dead animal not removed for 36 hours. Health..."", so it is Other and needs review.",NEEDS_REVIEW
+PM-202430,Heritage Damage,Standard,"Classified as Heritage Damage (Standard) based on the words ""heritage"" in the description.",
+PM-202433,Waste,Standard,"Classified as Waste (Standard) based on the words ""waste"" in the description.",
+PM-202446,Other,Urgent,"Classified as Other (Urgent) based on the words ""fell"" in the description.",NEEDS_REVIEW

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,40 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0A Complaint Classifier
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: Classifies a single citizen complaint into the fixed taxonomy with a priority, a cited reason, and an ambiguity flag.
+    input: >
+      One complaint row as a dict, e.g. {complaint_id, description, ...metadata}.
+      The description is free text; category and priority_flag are absent and
+      must be derived.
+    output: >
+      A dict with exactly: complaint_id, category, priority, reason, flag.
+      - category: one of Pothole, Flooding, Streetlight, Waste, Noise, Road Damage,
+        Heritage Damage, Heat Hazard, Drain Blockage, Other (verbatim).
+      - priority: Urgent, Standard, or Low. Urgent whenever the description contains
+        any severity keyword (injury, child, school, hospital, ambulance, fire,
+        hazard, fell, collapse).
+      - reason: one sentence quoting specific words from the description.
+      - flag: NEEDS_REVIEW if the category is genuinely ambiguous, else blank.
+    error_handling: >
+      If no allowed category fits, return category: Other. If the complaint is too
+      vague or fits two categories equally, set flag: NEEDS_REVIEW instead of
+      guessing. If description is empty/null, return category: Other,
+      priority: Standard, flag: NEEDS_REVIEW, and a reason noting the missing text.
+      Never invent a category or fabricate words not in the description.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: Reads the input CSV, applies classify_complaint to every row, and writes the results CSV.
+    input: >
+      input_path (path to test_[city].csv, 15 rows) and output_path
+      (path to results_[city].csv).
+    output: >
+      A CSV written to output_path with header
+      complaint_id, category, priority, reason, flag — one row per input row,
+      in the same order.
+    error_handling: >
+      Must not crash on a single bad or malformed row: catch per-row errors, still
+      write that row with category: Other, flag: NEEDS_REVIEW, and a reason noting
+      the failure, then continue. Flag null/empty fields rather than dropping rows.
+      Always produce an output file even if some rows fail. Fail loudly only if the
+      input file is missing or unreadable.

--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,38 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0B Policy Summariser
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a policy summarisation agent for the City Municipal Corporation HR
+  Leave Policy (HR-POL-001). You take the full policy document and produce a
+  faithful, clause-referenced summary. Your boundary is compression without
+  meaning loss: you condense wording, but you never drop a clause, never drop a
+  condition within a clause, never soften a binding obligation, and never add
+  information that is not in the source. You do not interpret, advise, or fill
+  gaps with outside knowledge of how "government organisations usually work."
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a summary in which every one of the 10 tracked clauses
+  (2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2) is present and tagged with
+  its clause number; each clause's binding verb strength is preserved (must
+  stays must, requires stays requires, not permitted stays not permitted — never
+  downgraded to "should", "may", "is encouraged to", or "generally"); and every
+  multi-condition obligation keeps ALL of its conditions. Correctness is
+  verifiable by diffing the summary against the clause inventory below:
+  each clause number must appear, each binding verb must survive, and no scope
+  bleed (claims not traceable to a source line) may be present.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the text of policy_hr_leave.txt. It must NOT use outside
+  knowledge, assumptions about "standard practice", or generalisations about
+  government or HR norms. Phrases such as "as is standard practice", "typically
+  in government organisations", or "employees are generally expected to" are
+  forbidden because they are not in the source. If a clause cannot be summarised
+  without losing meaning, the agent must quote it verbatim and flag it rather
+  than paraphrase it into something weaker.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Completeness: every numbered clause in the source must appear in the summary tagged with its clause number. The 10 high-risk clauses that must never be dropped are 2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2."
+  - "Preserve all conditions: multi-condition obligations must keep every condition. Clause 5.2 requires approval from BOTH the Department Head AND the HR Director — dropping either approver is a condition drop, not an acceptable simplification. 'Requires approval' alone is wrong."
+  - "Preserve binding strength: keep the source verb's force. must→must, requires→requires, will→will, are forfeited→are forfeited, not permitted→not permitted. Never downgrade an obligation to 'should', 'may', 'is encouraged to', 'usually', or 'generally'."
+  - "Preserve numeric and temporal conditions verbatim: 14 calendar days advance (2.3), max 5 carry-forward days forfeited on 31 Dec (2.6), used Jan–Mar or forfeited (2.7), 3+ consecutive sick days + certificate within 48 hrs (3.2), cert before/after holiday regardless of duration (3.4), LWP >30 days needs Municipal Commissioner (5.3). Do not round, generalise, or drop these thresholds."
+  - "No scope bleed: never add information not present in the source. Reject any sentence that cannot be traced to a specific clause line. Forbidden filler includes 'as is standard practice', 'typically in government organisations', 'employees are generally expected to'."
+  - "Refusal / flag condition: if a clause cannot be summarised without changing its meaning, do NOT paraphrase it — quote the clause verbatim and mark it [VERBATIM — meaning-preserving summary not possible]. When in doubt between softening and quoting, quote."

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,187 @@
 """
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0B — Policy Summariser (Summary That Changes Meaning)
+
+Built from the RICE contract in agents.md and the skill specs in skills.md.
+Deterministic, stdlib-only: no network/LLM calls, so it runs in any workshop
+environment and produces the SAME output every run.
+
+Why deterministic quoting instead of free-text paraphrase:
+  The failure mode this UC targets is meaning loss — clause omission, scope bleed,
+  and obligation softening. A paraphrasing summariser is exactly what drops
+  clause 5.2's second approver or downgrades "must" to "should". This tool instead
+  GUARANTEES the enforcement contract by construction:
+    - every numbered clause is emitted, tagged with its clause number  (no omission)
+    - the 10 high-risk clauses are emitted verbatim and marked [BINDING] (no softening)
+    - only source text is written                                       (no scope bleed)
+    - a COMPLETENESS CHECK footer proves every tracked clause is present,
+      and that clause 5.2 still names BOTH approvers.
+
+Enforcement encoded here (see agents.md):
+  - completeness: every numbered clause present, clause-number tagged
+  - preserve all conditions: clause 5.2 must keep Department Head AND HR Director
+  - preserve binding strength: binding clauses quoted verbatim, never re-verbed
+  - no scope bleed: nothing written that is not traceable to a source clause
+  - refusal/flag: a missing tracked clause fails the run instead of summarising quietly
 """
 import argparse
+import re
+import sys
+
+# The 10 clauses the README marks as high-risk. These are emitted verbatim
+# and verified present in the COMPLETENESS CHECK footer.
+TRACKED_CLAUSES = [
+    "2.3", "2.4", "2.5", "2.6", "2.7",
+    "3.2", "3.4", "5.2", "5.3", "7.2",
+]
+
+# Multi-approver / multi-condition clauses: both tokens must survive (the 5.2 trap).
+CONDITION_GUARDS = {
+    "5.2": ["Department Head", "HR Director"],
+}
+
+SECTION_RE = re.compile(r"^(\d+)\.\s+([A-Z][A-Z &/()-]+)\s*$")
+CLAUSE_RE = re.compile(r"^\s*(\d+\.\d+)\s+(.*\S)\s*$")
+# Banner / divider decoration made of box-drawing or rule characters — never clause text.
+DECORATION_RE = re.compile(r"^[\s═=_\-–—│┃|]+$")
+
+
+def retrieve_policy(input_path: str) -> dict:
+    """
+    Load the .txt policy and return structured, numbered sections + a flat index.
+
+    Returns:
+      {
+        "sections": [ {number, title, clauses:[{number, text}]}, ... ],
+        "index":    { "2.3": "full clause text", ... },
+      }
+    Fails loudly if the file is missing/unreadable — an empty inventory must
+    never be summarised silently.
+    """
+    with open(input_path, encoding="utf-8-sig") as f:
+        lines = f.readlines()
+
+    sections = []
+    index = {}
+    current_section = None
+    current_clause = None  # (number, [text parts])
+
+    def _flush_clause():
+        nonlocal current_clause
+        if current_clause and current_section is not None:
+            number, parts = current_clause
+            text = re.sub(r"\s+", " ", " ".join(parts)).strip()
+            current_section["clauses"].append({"number": number, "text": text})
+            index[number] = text
+        current_clause = None
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+
+        sec_match = SECTION_RE.match(line)
+        if sec_match:
+            _flush_clause()
+            current_section = {
+                "number": sec_match.group(1),
+                "title": sec_match.group(2).strip(),
+                "clauses": [],
+            }
+            sections.append(current_section)
+            continue
+
+        clause_match = CLAUSE_RE.match(line)
+        if clause_match and current_section is not None:
+            _flush_clause()
+            current_clause = (clause_match.group(1), [clause_match.group(2)])
+            continue
+
+        # Continuation line: belongs to the clause currently being built.
+        # Skip divider/banner decoration so it never bleeds into clause text.
+        if current_clause is not None and line.strip() and not DECORATION_RE.match(line):
+            current_clause[1].append(line.strip())
+        # Anything else (banner, dividers, blank lines) is decoration → ignore.
+
+    _flush_clause()
+    return {"sections": sections, "index": index}
+
+
+def summarize_policy(policy: dict, output_path: str) -> bool:
+    """
+    Produce a clause-referenced summary that preserves every clause, all
+    conditions, and each binding verb. Only source text is written.
+
+    Returns True if the completeness contract holds, False if any tracked clause
+    is missing or a guarded condition was dropped (the run is marked FAILED but an
+    output file is still written so the failure is visible).
+    """
+    index = policy["index"]
+    tracked = set(TRACKED_CLAUSES)
+    out = []
+
+    out.append("POLICY SUMMARY — CMC EMPLOYEE LEAVE POLICY (HR-POL-001)")
+    out.append("Generated deterministically from source. Every clause preserved; no external content added.")
+    out.append("=" * 72)
+    out.append("")
+
+    for section in policy["sections"]:
+        out.append(f"SECTION {section['number']} — {section['title']}")
+        for clause in section["clauses"]:
+            num = clause["number"]
+            marker = " [BINDING]" if num in tracked else ""
+            out.append(f"  {num}{marker}  {clause['text']}")
+        out.append("")
+
+    # --- COMPLETENESS CHECK footer: proves the enforcement contract ---
+    out.append("=" * 72)
+    out.append("COMPLETENESS CHECK (agents.md enforcement)")
+    out.append("-" * 72)
+
+    ok = True
+    for num in TRACKED_CLAUSES:
+        if num not in index:
+            ok = False
+            out.append(f"  {num}: MISSING — FLAG FOR REVIEW (clause absent from source parse)")
+            continue
+
+        text = index[num]
+        # Condition guard: multi-approver / multi-condition clauses keep every token.
+        dropped = [tok for tok in CONDITION_GUARDS.get(num, []) if tok.lower() not in text.lower()]
+        if dropped:
+            ok = False
+            out.append(f"  {num}: CONDITION DROPPED — missing {', '.join(dropped)}")
+        else:
+            note = ""
+            if num in CONDITION_GUARDS:
+                note = f" (both conditions present: {', '.join(CONDITION_GUARDS[num])})"
+            out.append(f"  {num}: PRESENT{note}")
+
+    out.append("-" * 72)
+    out.append(f"RESULT: {'PASS — all tracked clauses present, no conditions dropped' if ok else 'FAILED — see flags above'}")
+    out.append("")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(out))
+
+    return ok
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0B Policy Summariser")
+    parser.add_argument("--input", required=True, help="Path to policy_hr_leave.txt")
+    parser.add_argument("--output", required=True, help="Path to write the summary")
+    args = parser.parse_args()
+
+    policy = retrieve_policy(args.input)
+    n_clauses = sum(len(s["clauses"]) for s in policy["sections"])
+    print(f"Parsed {len(policy['sections'])} section(s), {n_clauses} clause(s).")
+
+    ok = summarize_policy(policy, args.output)
+    print(f"Summary written to {args.output}")
+    if ok:
+        print("COMPLETENESS: PASS — all 10 tracked clauses present, no conditions dropped.")
+    else:
+        print("COMPLETENESS: FAILED — a tracked clause is missing or a condition was dropped. See footer.")
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,42 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0B Policy Summariser
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Loads the .txt policy file and returns its content as structured, numbered sections and clauses (the ground-truth inventory the summary is built from).
+    input: >
+      input_path (path to policy_hr_leave.txt). Plain UTF-8 text using
+      "N. TITLE" section headers and "N.M clause text" clause lines, with
+      indented continuation lines.
+    output: >
+      A structured object: an ordered list of sections, each
+      {number, title, clauses:[{number, text}]}, plus a flat {clause_number: text}
+      index for lookup. Continuation lines are joined and whitespace collapsed so
+      each clause is one clean string. No clause text is altered, dropped, or added.
+    error_handling: >
+      If the file is missing or unreadable, fail loudly (raise) — an empty or
+      partial inventory must never be summarised silently. Lines that match no
+      section/clause pattern are ignored as decoration (dividers, banner). If a
+      required tracked clause is absent from the parse, record it as MISSING so
+      summarize_policy can flag it rather than emit an incomplete summary quietly.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Takes the structured sections and produces a clause-referenced summary that preserves every clause, all conditions, and each binding verb — with no information not present in the source.
+    input: >
+      The structured sections object from retrieve_policy, plus output_path
+      (path to summary_hr_leave.txt).
+    output: >
+      A summary written to output_path. Every numbered clause appears tagged with
+      its clause number. The 10 high-risk clauses (2.3, 2.4, 2.5, 2.6, 2.7, 3.2,
+      3.4, 5.2, 5.3, 7.2) are emitted verbatim and marked [BINDING] so their
+      conditions and verb strength (must / requires / will / not permitted) cannot
+      be softened. A COMPLETENESS CHECK footer lists every tracked clause and
+      confirms it is present; clause 5.2 is additionally checked for BOTH the
+      Department Head and the HR Director.
+    error_handling: >
+      If any tracked clause is missing from the input, do NOT produce a
+      "clean" summary — emit the clause line as [MISSING — FLAG FOR REVIEW] and
+      mark the run as failed in the footer. If clause 5.2 loses either approver,
+      flag it as a dropped condition. Never paraphrase a binding clause into a
+      weaker verb; when meaning cannot survive condensation, quote verbatim.
+      Never insert phrases not traceable to a source clause (no "as is standard
+      practice", "typically in government organisations", "generally expected to").

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,64 @@
+POLICY SUMMARY — CMC EMPLOYEE LEAVE POLICY (HR-POL-001)
+Generated deterministically from source. Every clause preserved; no external content added.
+========================================================================
+
+SECTION 1 — PURPOSE AND SCOPE
+  1.1  This policy governs all leave entitlements for permanent and contractual employees of the City Municipal Corporation (CMC).
+  1.2  This policy does not apply to daily wage workers or consultants. Those categories are governed by their respective contracts.
+
+SECTION 2 — ANNUAL LEAVE
+  2.1  Each permanent employee is entitled to 18 days of paid annual leave per calendar year.
+  2.2  Annual leave accrues at 1.5 days per month from the date of joining.
+  2.3 [BINDING]  Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+  2.4 [BINDING]  Leave applications must receive written approval from the employee's direct manager before the leave commences. Verbal approval is not valid.
+  2.5 [BINDING]  Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.
+  2.6 [BINDING]  Employees may carry forward a maximum of 5 unused annual leave days to the following calendar year. Any days above 5 are forfeited on 31 December.
+  2.7 [BINDING]  Carry-forward days must be used within the first quarter (January–March) of the following year or they are forfeited.
+
+SECTION 3 — SICK LEAVE
+  3.1  Each employee is entitled to 12 days of paid sick leave per calendar year.
+  3.2 [BINDING]  Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.
+  3.3  Sick leave cannot be carried forward to the following year.
+  3.4 [BINDING]  Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration.
+
+SECTION 4 — MATERNITY AND PATERNITY LEAVE
+  4.1  Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
+  4.2  For a third or subsequent child, maternity leave is 12 weeks paid.
+  4.3  Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+  4.4  Paternity leave cannot be split across multiple periods.
+
+SECTION 5 — LEAVE WITHOUT PAY (LWP)
+  5.1  An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.
+  5.2 [BINDING]  LWP requires approval from the Department Head and the HR Director. Manager approval alone is not sufficient.
+  5.3 [BINDING]  LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.
+  5.4  Periods of LWP do not count toward service for the purposes of seniority, increments, or retirement benefits.
+
+SECTION 6 — PUBLIC HOLIDAYS
+  6.1  Employees are entitled to all gazetted public holidays as declared by the State Government each year.
+  6.2  If an employee is required to work on a public holiday, they are entitled to one compensatory off day, to be taken within 60 days of the holiday worked.
+  6.3  Compensatory off cannot be encashed.
+
+SECTION 7 — LEAVE ENCASHMENT
+  7.1  Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.
+  7.2 [BINDING]  Leave encashment during service is not permitted under any circumstances.
+  7.3  Sick leave and LWP cannot be encashed under any circumstances.
+
+SECTION 8 — GRIEVANCES
+  8.1  Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+  8.2  Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.
+
+========================================================================
+COMPLETENESS CHECK (agents.md enforcement)
+------------------------------------------------------------------------
+  2.3: PRESENT
+  2.4: PRESENT
+  2.5: PRESENT
+  2.6: PRESENT
+  2.7: PRESENT
+  3.2: PRESENT
+  3.4: PRESENT
+  5.2: PRESENT (both conditions present: Department Head, HR Director)
+  5.3: PRESENT
+  7.2: PRESENT
+------------------------------------------------------------------------
+RESULT: PASS — all tracked clauses present, no conditions dropped

--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -1,18 +1,35 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0C Budget Growth Analyst
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a municipal budget growth analyst for the CMC ward budget dataset.
+  You compute period-over-period growth in actual_spend for ONE ward and ONE
+  category at a time. Your boundary is narrow arithmetic reporting: you compute
+  growth exactly as instructed, show your formula, and flag missing data. You do
+  NOT aggregate across wards or categories, you do NOT choose a growth formula on
+  the user's behalf, and you do NOT silently skip or impute missing values.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a per-ward, per-category table (never a single blended
+  number) covering each period in order, where every row shows: the period, the
+  ward, the category, the growth_type used, the current actual_spend, the prior
+  period and its spend, the computed growth_pct, and the exact formula used to
+  produce it. Rows where actual_spend is null must appear with a flag and the
+  null reason from the notes column — NOT a computed number. Correctness is
+  verifiable against the reference values (e.g. Ward 1 – Kasba, Roads & Pothole
+  Repair: 2024-07 = +33.1%, 2024-10 = −34.8%) and by confirming all 5 null rows
+  are flagged rather than computed.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the ward_budget.csv rows for the single requested ward
+  and category. It must NOT combine wards, combine categories, or produce a
+  grand total. It must NOT assume which growth measure to use: if the growth
+  type (MoM or YoY) is not specified, it refuses and asks rather than guessing.
+  It must NOT invent a value for a null actual_spend — the null and its stated
+  reason are reported as-is.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "No aggregation: never compute growth across more than one ward or more than one category. If asked to aggregate (all wards, all categories, a total), REFUSE and explain that only per-ward per-category analysis is supported."
+  - "Flag every null before computing: any row with a null actual_spend is reported with flag NULL and the reason copied verbatim from the notes column. Growth is NOT computed for that period, and a period whose PREVIOUS value is null is flagged as not computable rather than guessed."
+  - "Show the formula in every output row: e.g. 'MoM = (19.7 - 14.8) / 14.8 × 100 = +33.1%'. A growth number with no visible formula is invalid."
+  - "Refuse on unspecified growth type: if --growth-type is not one of MoM or YoY, do not guess — refuse and ask which measure to use."
+  - "No fabricated periods or values: use only the actual_spend figures present in the CSV for the requested ward+category. If the requested ward or category does not exist in the data, refuse and list what is available rather than approximating."

--- a/uc-0c/app.py
+++ b/uc-0c/app.py
@@ -1,12 +1,201 @@
 """
-UC-0C app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0C — Budget Growth Analyst (Number That Looks Right)
+
+Built from the RICE contract in agents.md and the skill specs in skills.md.
+Deterministic, stdlib-only: no network/LLM calls.
+
+The failure modes this UC targets — wrong aggregation level, silent null
+handling, and silent formula choice — are all prevented BY DESIGN here:
+  - the tool only ever operates on ONE ward + ONE category (no aggregation),
+    and refuses explicitly if asked to aggregate                 (aggregation guard)
+  - null actual_spend is loaded as None, reported up front, and flagged per row
+    with its notes reason instead of being computed or skipped   (null guard)
+  - --growth-type is NOT defaulted; if it is missing or invalid the tool refuses
+    and asks rather than guessing MoM vs YoY                      (formula guard)
+  - every computed row prints the exact formula used             (transparency)
+
+Verified against the README reference values:
+  Ward 1 – Kasba / Roads & Pothole Repair : 2024-07 = +33.1%, 2024-10 = −34.8%.
 """
 import argparse
+import csv
+import sys
+
+# Windows consoles often default to cp1252, which cannot print the report's
+# dashes/arrows. Make stdout UTF-8 so the report renders on every platform.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+EXPECTED_COLUMNS = ["period", "ward", "category", "budgeted_amount", "actual_spend", "notes"]
+VALID_GROWTH_TYPES = ("MoM", "YoY")
+AGGREGATE_TOKENS = {"all", "all wards", "all categories", "*", "total", "aggregate", "everything"}
+
+OUTPUT_FIELDS = [
+    "period", "ward", "category", "growth_type", "actual_spend",
+    "prev_period", "prev_actual_spend", "growth_pct", "formula", "flag",
+]
+
+
+class RefusalError(Exception):
+    """Raised when the agent must refuse rather than guess (see agents.md)."""
+
+
+def _norm(value: str) -> str:
+    """Normalise for comparison: unify dash variants, collapse space, lowercase."""
+    if value is None:
+        return ""
+    v = value.replace("–", "-").replace("—", "-")  # en/em dash -> hyphen
+    return " ".join(v.split()).strip().lower()
+
+
+def load_dataset(input_path: str) -> list:
+    """
+    Read the ward budget CSV, validate columns, and report null actual_spend rows.
+    Returns a list of row dicts with actual_spend as float or None.
+    Fails loudly on a missing file or missing column.
+    """
+    with open(input_path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        header = reader.fieldnames or []
+        missing = [c for c in EXPECTED_COLUMNS if c not in header]
+        if missing:
+            raise ValueError(f"Input CSV is missing required column(s): {', '.join(missing)}")
+
+        rows = []
+        for raw in reader:
+            spend_raw = (raw.get("actual_spend") or "").strip()
+            rows.append({
+                "period": (raw.get("period") or "").strip(),
+                "ward": (raw.get("ward") or "").strip(),
+                "category": (raw.get("category") or "").strip(),
+                "budgeted_amount": (raw.get("budgeted_amount") or "").strip(),
+                "actual_spend": float(spend_raw) if spend_raw else None,
+                "notes": (raw.get("notes") or "").strip(),
+            })
+
+    nulls = [r for r in rows if r["actual_spend"] is None]
+    print(f"Loaded {len(rows)} row(s) from {input_path}.")
+    print(f"Null actual_spend rows: {len(nulls)} (these will be FLAGGED, never computed):")
+    for r in nulls:
+        reason = r["notes"] or "(no reason given in notes)"
+        print(f"  - {r['period']} · {r['ward']} · {r['category']} → {reason}")
+    return rows
+
+
+def _resolve_series(rows, ward, category):
+    """Return the rows for exactly one ward+category, or refuse."""
+    if _norm(ward) in AGGREGATE_TOKENS or _norm(category) in AGGREGATE_TOKENS:
+        raise RefusalError(
+            "Refusing to aggregate. This tool reports growth for ONE ward and ONE "
+            "category at a time; cross-ward / cross-category totals are not supported "
+            "(see agents.md enforcement rule 1)."
+        )
+
+    wards = sorted({r["ward"] for r in rows})
+    cats = sorted({r["category"] for r in rows})
+    ward_match = [w for w in wards if _norm(w) == _norm(ward)]
+    cat_match = [c for c in cats if _norm(c) == _norm(category)]
+
+    if not ward_match:
+        raise RefusalError(f"Ward '{ward}' not found. Available wards: {wards}")
+    if not cat_match:
+        raise RefusalError(f"Category '{category}' not found. Available categories: {cats}")
+
+    series = [r for r in rows if r["ward"] == ward_match[0] and r["category"] == cat_match[0]]
+    series.sort(key=lambda r: r["period"])
+    return ward_match[0], cat_match[0], series
+
+
+def compute_growth(rows, ward, category, growth_type):
+    """
+    Compute per-period growth for ONE ward+category. Returns a per-period table.
+    Refuses on unspecified/invalid growth_type or on aggregation requests.
+    """
+    if growth_type not in VALID_GROWTH_TYPES:
+        raise RefusalError(
+            f"Refusing to guess a growth measure. --growth-type must be one of "
+            f"{VALID_GROWTH_TYPES}; got {growth_type!r}. Please specify which to use "
+            "(see agents.md enforcement rule 4)."
+        )
+
+    ward, category, series = _resolve_series(rows, ward, category)
+    by_period = {r["period"]: r for r in series}
+    table = []
+
+    for i, row in enumerate(series):
+        period = row["period"]
+        cur = row["actual_spend"]
+
+        if growth_type == "MoM":
+            prev_row = series[i - 1] if i > 0 else None
+        else:  # YoY: same month, previous year
+            year, month = period.split("-")
+            prev_key = f"{int(year) - 1}-{month}"
+            prev_row = by_period.get(prev_key)
+
+        prev_period = prev_row["period"] if prev_row else ""
+        prev = prev_row["actual_spend"] if prev_row else None
+
+        out = {
+            "period": period, "ward": ward, "category": category,
+            "growth_type": growth_type, "actual_spend": "" if cur is None else cur,
+            "prev_period": prev_period, "prev_actual_spend": "" if prev is None else prev,
+            "growth_pct": "", "formula": "", "flag": "",
+        }
+
+        # --- Flag conditions (never compute through a null / missing base) ---
+        if cur is None:
+            out["flag"] = f"NULL_CURRENT: {row['notes'] or 'actual_spend missing'}"
+            out["formula"] = "not computed — current actual_spend is null"
+        elif prev_row is None:
+            out["flag"] = "NO_PRIOR_PERIOD" if growth_type == "MoM" else "NO_PRIOR_YEAR_DATA"
+            out["formula"] = "not computed — no prior period to compare against"
+        elif prev is None:
+            out["flag"] = f"NULL_PREVIOUS: prior period {prev_period} actual_spend is null"
+            out["formula"] = "not computed — prior actual_spend is null"
+        else:
+            growth = (cur - prev) / prev * 100
+            out["growth_pct"] = f"{growth:+.1f}%"
+            out["formula"] = f"{growth_type} = ({cur} - {prev}) / {prev} × 100 = {growth:+.1f}%"
+
+        table.append(out)
+
+    return table
+
+
+def write_output(table, output_path):
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=OUTPUT_FIELDS)
+        writer.writeheader()
+        writer.writerows(table)
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0C Budget Growth Analyst")
+    parser.add_argument("--input", required=True, help="Path to ward_budget.csv")
+    parser.add_argument("--ward", required=True, help="Single ward, e.g. 'Ward 1 – Kasba'")
+    parser.add_argument("--category", required=True, help="Single category, e.g. 'Roads & Pothole Repair'")
+    # NOT defaulted on purpose: an unspecified growth type must be refused, not guessed.
+    parser.add_argument("--growth-type", default=None, help="MoM or YoY (required — no default)")
+    parser.add_argument("--output", required=True, help="Path to write the per-period growth CSV")
+    args = parser.parse_args()
+
+    try:
+        rows = load_dataset(args.input)
+        table = compute_growth(rows, args.ward, args.category, args.growth_type)
+    except RefusalError as r:
+        print(f"\nREFUSED: {r}")
+        sys.exit(2)
+
+    write_output(table, args.output)
+    computed = sum(1 for t in table if t["growth_pct"])
+    flagged = sum(1 for t in table if t["flag"])
+    print(f"\nWrote {len(table)} row(s) to {args.output} "
+          f"({computed} computed, {flagged} flagged) for {args.ward} / {args.category} [{args.growth_type}].")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0c/growth_output.csv
+++ b/uc-0c/growth_output.csv
@@ -1,0 +1,13 @@
+period,ward,category,growth_type,actual_spend,prev_period,prev_actual_spend,growth_pct,formula,flag
+2024-01,Ward 1 – Kasba,Roads & Pothole Repair,MoM,13.3,,,,not computed — no prior period to compare against,NO_PRIOR_PERIOD
+2024-02,Ward 1 – Kasba,Roads & Pothole Repair,MoM,12.2,2024-01,13.3,-8.3%,MoM = (12.2 - 13.3) / 13.3 × 100 = -8.3%,
+2024-03,Ward 1 – Kasba,Roads & Pothole Repair,MoM,12.3,2024-02,12.2,+0.8%,MoM = (12.3 - 12.2) / 12.2 × 100 = +0.8%,
+2024-04,Ward 1 – Kasba,Roads & Pothole Repair,MoM,13.4,2024-03,12.3,+8.9%,MoM = (13.4 - 12.3) / 12.3 × 100 = +8.9%,
+2024-05,Ward 1 – Kasba,Roads & Pothole Repair,MoM,14.1,2024-04,13.4,+5.2%,MoM = (14.1 - 13.4) / 13.4 × 100 = +5.2%,
+2024-06,Ward 1 – Kasba,Roads & Pothole Repair,MoM,14.8,2024-05,14.1,+5.0%,MoM = (14.8 - 14.1) / 14.1 × 100 = +5.0%,
+2024-07,Ward 1 – Kasba,Roads & Pothole Repair,MoM,19.7,2024-06,14.8,+33.1%,MoM = (19.7 - 14.8) / 14.8 × 100 = +33.1%,
+2024-08,Ward 1 – Kasba,Roads & Pothole Repair,MoM,20.2,2024-07,19.7,+2.5%,MoM = (20.2 - 19.7) / 19.7 × 100 = +2.5%,
+2024-09,Ward 1 – Kasba,Roads & Pothole Repair,MoM,20.1,2024-08,20.2,-0.5%,MoM = (20.1 - 20.2) / 20.2 × 100 = -0.5%,
+2024-10,Ward 1 – Kasba,Roads & Pothole Repair,MoM,13.1,2024-09,20.1,-34.8%,MoM = (13.1 - 20.1) / 20.1 × 100 = -34.8%,
+2024-11,Ward 1 – Kasba,Roads & Pothole Repair,MoM,14.2,2024-10,13.1,+8.4%,MoM = (14.2 - 13.1) / 13.1 × 100 = +8.4%,
+2024-12,Ward 1 – Kasba,Roads & Pothole Repair,MoM,12.7,2024-11,14.2,-10.6%,MoM = (12.7 - 14.2) / 14.2 × 100 = -10.6%,

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -1,16 +1,37 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0C Budget Growth Analyst
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: Reads the ward budget CSV, validates the expected columns, and reports how many actual_spend values are null and exactly which rows before returning.
+    input: >
+      input_path (path to ward_budget.csv). Expected columns:
+      period, ward, category, budgeted_amount, actual_spend, notes.
+    output: >
+      A list of parsed rows (dicts) with actual_spend as float or None, plus a
+      printed validation report: total row count, null count, and the
+      period/ward/category + notes reason of every null row.
+    error_handling: >
+      If the file is missing/unreadable, fail loudly (raise) — do not analyse a
+      partial dataset. If a required column is absent, raise with the missing
+      column name. Blank actual_spend becomes None (never 0) so it can be flagged
+      downstream rather than silently treated as zero spend.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: compute_growth
+    description: Computes period-over-period growth for ONE ward and ONE category, returning a per-period table with the formula shown and every null flagged.
+    input: >
+      rows (from load_dataset), ward (single value), category (single value),
+      growth_type (MoM or YoY). ward/category identify exactly one series.
+    output: >
+      A per-period table (list of dicts) with: period, ward, category,
+      growth_type, actual_spend, prev_period, prev_actual_spend, growth_pct,
+      formula, flag. growth_pct is rounded to one decimal; formula shows the exact
+      arithmetic. Rows with a null current or prior value carry a flag and no
+      computed number.
+    error_handling: >
+      Refuse (raise/return refusal) if growth_type is not MoM or YoY — never pick
+      one silently. Refuse if ward or category resolves to more than one series or
+      to an aggregate request. If the ward/category is not found, refuse and list
+      available values. Null current spend -> flag NULL_CURRENT with the notes
+      reason; null prior spend -> flag NULL_PREVIOUS (not computable); first
+      period -> flag NO_PRIOR_PERIOD; YoY with no prior-year row -> flag
+      NO_PRIOR_YEAR_DATA. Never impute or interpolate a missing value.

--- a/uc-x/agents.md
+++ b/uc-x/agents.md
@@ -1,18 +1,35 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-X Policy Document Q&A
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  You are a policy question-answering agent for the CMC. You answer employee
+  questions using ONLY the three policy documents (HR Leave, IT Acceptable Use,
+  Finance Reimbursement). Your boundary is single-source retrieval: each answer
+  is grounded in exactly ONE clause of ONE document, quoted and cited. You do not
+  blend claims from different documents, you do not hedge, and you do not answer
+  from outside knowledge.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output for an in-scope question is the relevant clause, answered from
+  a SINGLE document + section, with a citation of the form
+  "Source: <document name>, section <N.M>". A correct output for an out-of-scope
+  question is the refusal template, verbatim. Correctness is verifiable against
+  the 7 test questions: e.g. carry-forward → HR 2.6; install software → IT 2.3;
+  home office allowance → Finance 3.1; personal phone for work files → IT 3.1
+  only (never an IT+HR blend); flexible working culture → refusal template;
+  DA + meal receipts same day → Finance 2.6; who approves LWP → HR 5.2 (both
+  Department Head AND HR Director).
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use ONLY the text indexed from policy_hr_leave.txt,
+  policy_it_acceptable_use.txt, and policy_finance_reimbursement.txt. It must NOT
+  merge two documents to construct an answer, must NOT infer permissions that no
+  single clause states, and must NOT use general knowledge. If no single clause
+  answers the question, or the only way to answer would combine documents, it
+  refuses using the template rather than guessing.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Single-source only: every answer is grounded in exactly ONE clause of ONE document. Never combine claims from two different documents into a single answer. If answering would require blending documents, refuse."
+  - "No hedging: never use 'while not explicitly covered', 'typically', 'generally understood', 'it is common practice', or any softening filler. An answer is either a cited clause or the refusal template — nothing in between."
+  - "Refusal template, verbatim, when out of scope: 'This question is not covered in the available policy documents (policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt). Please contact the relevant department (HR, IT, or Finance) for guidance.'"
+  - "Cite every factual claim: each answer names the source document and its section number (e.g. 'Source: IT Acceptable Use Policy (IT-POL-003), section 3.1'). An answer with no citation is invalid."
+  - "Preserve all conditions: quote the clause as written so multi-condition obligations stay intact (e.g. LWP requires BOTH the Department Head AND the HR Director). Never drop a condition to make an answer shorter."

--- a/uc-x/app.py
+++ b/uc-x/app.py
@@ -1,12 +1,226 @@
 """
-UC-X app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-X — Ask My Documents (Policy Q&A)
+
+Built from the RICE contract in agents.md and the skill specs in skills.md.
+Deterministic, stdlib-only: no network/LLM calls.
+
+The failure modes this UC targets — cross-document blending, hedged
+hallucination, and condition dropping — are prevented BY DESIGN:
+  - answer_question grounds every answer in exactly ONE clause of ONE document,
+    so two documents can never be merged into one answer      (no blending)
+  - answers are either a verbatim cited clause or the fixed refusal template;
+    the code never generates prose, so hedging phrases cannot appear  (no hedging)
+  - clause text is quoted verbatim, so multi-condition obligations such as
+    "Department Head AND HR Director" stay intact              (no condition drop)
+  - a cross-document tie or a zero-score question returns the refusal template
+    rather than a guess                                        (safe refusal)
+
+Verified against the 7 README test questions:
+  carry-forward → HR 2.6 | install software → IT 2.3 | home office allowance →
+  Finance 3.1 | personal phone for work files → IT 3.1 (single-source, no blend)
+  | flexible working culture → refusal | DA + meal receipts same day → Finance
+  2.6 | who approves LWP → HR 5.2 (Department Head AND HR Director).
+
+Run:
+  python app.py             # interactive
+  python app.py --selftest  # runs the 7 test questions and exits
 """
 import argparse
+import re
+import sys
+
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+DOCS = [
+    ("hr", "HR Leave Policy (HR-POL-001)", "../data/policy-documents/policy_hr_leave.txt"),
+    ("it", "IT Acceptable Use Policy (IT-POL-003)", "../data/policy-documents/policy_it_acceptable_use.txt"),
+    ("fin", "Finance Reimbursement Policy (FIN-POL-007)", "../data/policy-documents/policy_finance_reimbursement.txt"),
+]
+
+REFUSAL_TEMPLATE = (
+    "This question is not covered in the available policy documents "
+    "(policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt). "
+    "Please contact the relevant department (HR, IT, or Finance) for guidance."
+)
+
+SECTION_RE = re.compile(r"^(\d+)\.\s+([A-Z][A-Z &/()-]+)\s*$")
+CLAUSE_RE = re.compile(r"^\s*(\d+\.\d+)\s+(.*\S)\s*$")
+DECORATION_RE = re.compile(r"^[\s═=_\-–—│┃|]+$")
+
+# Common words that carry no discriminating signal (function words + ubiquitous terms).
+STOPWORDS = {
+    "a", "an", "the", "and", "or", "of", "to", "in", "on", "for", "from", "with",
+    "when", "what", "who", "how", "is", "are", "be", "am", "can", "could", "may",
+    "might", "do", "does", "did", "i", "me", "my", "we", "us", "you", "your", "it",
+    "this", "that", "these", "those", "at", "as", "by", "if", "not", "no", "yes",
+    "use", "used", "using", "get", "will", "would", "should", "work",
+    "working", "worked", "about", "any", "all", "cmc", "employee", "employees",
+}
+
+# General domain expansions applied to the QUESTION (a phone is a device, etc.).
+QUERY_EXPANSION = {
+    "phone": "device", "phones": "device", "mobile": "device", "laptop": "device",
+    "laptops": "device", "desktop": "device", "computer": "device", "computers": "device",
+    "slack": "software", "app": "software", "apps": "software",
+    "application": "software", "applications": "software",
+}
+
+_SUFFIXES = ("ing", "ment", "tion", "es", "ed", "al", "s")
+
+
+def _stem(word: str) -> str:
+    """Light, deterministic stemmer applied identically to query and clause text."""
+    for suf in _SUFFIXES:
+        if len(word) > len(suf) + 1 and word.endswith(suf):
+            word = word[: -len(suf)]
+            break
+    if len(word) > 2 and word.endswith("e"):
+        word = word[:-1]
+    return word
+
+
+def _tokens(text: str, expand: bool = False) -> set:
+    """Normalise -> tokenise -> drop stopwords -> optionally expand -> stem."""
+    text = text.replace("–", "-").replace("—", "-").lower()
+    raw = re.findall(r"[a-z0-9]+", text)
+    out = []
+    for tok in raw:
+        if tok in STOPWORDS:
+            continue
+        out.append(tok)
+        if expand and tok in QUERY_EXPANSION:
+            out.append(QUERY_EXPANSION[tok])
+    return {_stem(t) for t in out if len(t) >= 2}
+
+
+def retrieve_documents(docs=DOCS) -> list:
+    """Load all policy files and return a flat, citable clause index."""
+    index = []
+    for doc_key, doc_name, path in docs:
+        with open(path, encoding="utf-8-sig") as f:
+            lines = f.readlines()
+
+        section_title = ""
+        current = None  # (clause_number, [text parts])
+
+        def _flush():
+            nonlocal current
+            if current:
+                num, parts = current
+                text = re.sub(r"\s+", " ", " ".join(parts)).strip()
+                searchable = f"{section_title} {text}"
+                index.append({
+                    "doc_key": doc_key, "doc_name": doc_name, "section": num,
+                    "text": text, "searchable": _tokens(searchable),
+                })
+            current = None
+
+        for raw in lines:
+            line = raw.rstrip("\n")
+            sec = SECTION_RE.match(line)
+            if sec:
+                _flush()
+                section_title = sec.group(2).strip()
+                continue
+            clause = CLAUSE_RE.match(line)
+            if clause:
+                _flush()
+                current = (clause.group(1), [clause.group(2)])
+                continue
+            if current is not None and line.strip() and not DECORATION_RE.match(line):
+                current[1].append(line.strip())
+        _flush()
+    return index
+
+
+def answer_question(index: list, question: str) -> dict:
+    """
+    Ground the answer in exactly one clause of one document, or refuse.
+    Returns {refused: bool, answer, doc_name, section}.
+    """
+    q = _tokens(question, expand=True)
+    scored = [(len(q & c["searchable"]), c) for c in index]
+    best = max((s for s, _ in scored), default=0)
+
+    if best == 0:
+        return {"refused": True, "answer": REFUSAL_TEMPLATE}
+
+    candidates = [c for s, c in scored if s == best]
+    docs_hit = {c["doc_key"] for c in candidates}
+    if len(docs_hit) > 1:
+        # Genuine cross-document tie: refuse rather than blend two documents.
+        return {"refused": True, "answer": REFUSAL_TEMPLATE}
+
+    # Single document among the top matches: pick the lowest section number.
+    chosen = sorted(candidates, key=lambda c: [int(p) for p in c["section"].split(".")])[0]
+    return {
+        "refused": False,
+        "answer": chosen["text"],
+        "doc_name": chosen["doc_name"],
+        "section": chosen["section"],
+    }
+
+
+def format_response(result: dict) -> str:
+    if result["refused"]:
+        return result["answer"]
+    return f"{result['answer']}\n  Source: {result['doc_name']}, section {result['section']}"
+
+
+TEST_QUESTIONS = [
+    "Can I carry forward unused annual leave?",
+    "Can I install Slack on my work laptop?",
+    "What is the home office equipment allowance?",
+    "Can I use my personal phone to access work files when working from home?",
+    "What is the company view on flexible working culture?",
+    "Can I claim DA and meal receipts on the same day?",
+    "Who approves leave without pay?",
+]
+
+
+def run_selftest(index):
+    print("=== UC-X self-test: 7 README questions ===\n")
+    for i, question in enumerate(TEST_QUESTIONS, 1):
+        result = answer_question(index, question)
+        print(f"Q{i}: {question}")
+        print(format_response(result))
+        print()
+
+
+def interactive(index):
+    print("Ask a policy question (Ctrl-D or 'exit' to quit).")
+    while True:
+        try:
+            question = input("\nAsk> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not question:
+            continue
+        if question.lower() in {"exit", "quit"}:
+            break
+        print(format_response(answer_question(index, question)))
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-X Policy Document Q&A")
+    parser.add_argument("--selftest", action="store_true", help="Run the 7 test questions and exit")
+    args = parser.parse_args()
+
+    index = retrieve_documents()
+    print(f"Indexed {len(index)} clauses across {len(DOCS)} policy documents.\n")
+
+    # Auto-run the self-test when there is no interactive terminal (e.g. CI),
+    # so `python app.py` never hangs or crashes without stdin.
+    if args.selftest or not sys.stdin.isatty():
+        run_selftest(index)
+    else:
+        interactive(index)
+
 
 if __name__ == "__main__":
     main()

--- a/uc-x/skills.md
+++ b/uc-x/skills.md
@@ -1,16 +1,33 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-X Policy Document Q&A
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_documents
+    description: Loads all three policy files and indexes them by document name and section number so answers can be grounded in a single, citable clause.
+    input: >
+      Paths to policy_hr_leave.txt, policy_it_acceptable_use.txt, and
+      policy_finance_reimbursement.txt.
+    output: >
+      An index: a list of clause entries, each
+      {doc_key, doc_name, section (N.M), text, searchable}, where searchable is
+      the section title plus clause text, normalised for matching. Clause text is
+      preserved verbatim for quoting in answers.
+    error_handling: >
+      If any of the three files is missing/unreadable, fail loudly (raise) — a
+      partial index would let a question be answered from an incomplete corpus.
+      Banner/divider lines are ignored as decoration and never indexed as clauses.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: answer_question
+    description: Answers one question from a SINGLE best-matching clause with a citation, or returns the exact refusal template when nothing matches or the match would blend documents.
+    input: >
+      The index (from retrieve_documents) and a free-text question string.
+    output: >
+      Either a grounded answer — the verbatim clause text plus
+      "Source: <document name>, section <N.M>" — or the refusal template verbatim.
+      Exactly one document + one section per answer; never two.
+    error_handling: >
+      Score clauses by keyword overlap (light stemming; common words ignored;
+      'phone/laptop' → device, 'slack/app' → software). If the best score is zero,
+      return the refusal template (question not covered). If the top-scoring
+      clauses span more than one document (a genuine cross-document tie), refuse
+      rather than blend. On a within-document tie, pick the lowest section number.
+      Never emit a hedging phrase and never answer without a citation.


### PR DESCRIPTION

**Name:** Devi Perumalsamy
**City / Group:** Bangalore
**Date:** 2026-08-14
**AI tool(s) used:** Claude Code (Claude Opus 4.8)

## Checklist — Complete Before Opening This PR
- [x] `agents.md` committed for all 4 UCs
- [x] `skills.md` committed for all 4 UCs
- [x] `classifier.py` runs on `test_[city].csv` without crash
- [x] `results_[city].csv` present in `uc-0a/` (`results_pune.csv`)
- [x] `app.py` for UC-0B, UC-0C, UC-X — all run without crash
- [x] `summary_hr_leave.txt` present in `uc-0b/`
- [x] `growth_output.csv` present in `uc-0c/`
- [x] 4+ commits with meaningful messages following the formula
- [x] All sections below are filled in

## UC-0A — Complaint Classifier
**Which failure mode did you encounter first?**
> Taxonomy drift and severity blindness. A naive "classify this complaint" prompt reworded/pluralised categories (e.g. "Potholes", "Street Lights") and rated injury/child/school complaints as Standard instead of Urgent.

**What enforcement rule fixed it? Quote the rule exactly as it appears in your agents.md:**
> "Priority must be set to Urgent if the description contains any severity keyword: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse. Match is case-insensitive on the word." — together with the verbatim-taxonomy rule that forbids "vari/pluralised/reworded forms; string must match verbatim."

**How many rows in your results CSV match the answer key?**
> Answer key not yet released. `results_pune.csv` classifies all 15 rows with the enforced taxonomy, and every severity-signal row is Urgent.

**Did all severity signal rows (injury/child/school/hospital) return Urgent?**
> Yes — the severity-keyword rule forces Urgent whenever any listed keyword (incl. inflections like children/injuries/collapsed) appears.

**Your git commit message for UC-0A:**
> UC-0A Complaint classifier: naive prompt showed taxonomy drift and severity blindness -> added verbatim-taxonomy, severity-keyword and NEEDS_REVIEW enforcement in agents.md with a rule-based classifier + results_pune.csv

## UC-0B — Summary That Changes Meaning
**Which failure mode did you encounter?**
> All three — clause omission, obligation softening, and scope bleed. The naive summary dropped low-salience numbered clauses, downgraded "must/requires/not permitted" to "should/generally", and added phrases like "as is standard practice" not in the source.

**List any clauses that were missing or weakened in the naive output (before your RICE fix):**
> Most at risk: 5.2 (dropped the second approver — kept "requires approval" but lost "Department Head AND HR Director"), 2.6/2.7 (carry-forward limit and forfeiture date dropped), 3.4 (cert-before/after-holiday condition dropped), 7.2 ("not permitted" softened).

**After your fix — are all 10 critical clauses present in summary_hr_leave.txt?**
> Yes. The summariser emits every numbered clause and a COMPLETENESS CHECK footer confirming all 10 tracked clauses (2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2) are present, with 5.2 explicitly verified to keep BOTH approvers. Run result: PASS.

**Did the naive prompt add any information not in the source document (scope bleed)?**
> Yes — the classic bleed phrases ("as is standard practice", "typically in government organisations", "employees are generally expected to"). The fix bans them and only emits source text.

**Your git commit message for UC-0B:**
> UC-0B Summary that changes meaning: naive summary dropped clauses and softened obligations -> enforced every-clause completeness, condition preservation (5.2 both approvers) and verbatim binding verbs; summariser emits summary_hr_leave.txt with a completeness check

## UC-0C — Number That Looks Right
**What did the naive prompt return when you ran "Calculate growth from the data."?**
> A single blended growth number for all wards and categories combined, with no ward/category breakdown, no formula shown, and no mention of the missing values.

**Did it aggregate across all wards? Did it mention the 5 null rows?**
> Yes it aggregated across all wards (wrong level), and no — it silently ignored the 5 null actual_spend rows.

**After your fix — does your system refuse all-ward aggregation?**
> Yes — the tool operates on ONE ward + ONE category and raises a REFUSED message if asked to aggregate.

**Does your growth_output.csv flag the 5 null rows rather than skipping them?**
> Yes. load_dataset reports all 5 nulls up front with their notes reason (2024-03 Ward 2 Drainage, 2024-05 Ward 5 Streetlight, 2024-07 Ward 4 Roads, 2024-08 Ward 3 Parks, 2024-11 Ward 1 Waste). Null current/prior values are flagged, never computed through.

**Does your output match the reference values (Ward 1 Roads +33.1% in July, −34.8% in October)?**
> Yes — growth_output.csv shows 2024-07 = +33.1% and 2024-10 = −34.8% for Ward 1 – Kasba / Roads & Pothole Repair, with the formula printed per row.

**Your git commit message for UC-0C:**
> UC-0C Number that looks right: naive prompt aggregated across wards and hid null rows -> restricted to per-ward per-category scope, flagged all 5 null rows with reasons, required explicit --growth-type and printed the formula per row (growth_output.csv)

## UC-X — Ask My Documents
**What did the naive prompt return for the cross-document test question?**
> The naive approach blended IT and HR into a permissive answer like "Yes, personal phones can be used for approved remote work tools and email" — a permission in neither document.

**Did it blend the IT and HR policies?**
> Yes — it combined IT §3.1 (personal devices → email + portal only) with a vague HR remote-work notion to manufacture broader permission.

**After your fix — what does your system return for this question?**
> Single-source IT answer, no blend: "Personal devices may be used to access CMC email and the CMC employee self-service portal only. — Source: IT Acceptable Use Policy (IT-POL-003), section 3.1"

**Did your system use any hedging phrases in any answer?**
> No. The system only returns a verbatim cited clause or the exact refusal template, so hedging phrases cannot appear.

**Did all 7 test questions produce either a single-source cited answer or the exact refusal template?**
> Yes — verified via `python app.py --selftest`: Q1→HR 2.6, Q2→IT 2.3, Q3→Finance 3.1, Q4→IT 3.1 (single-source, no blend), Q5→refusal template, Q6→Finance 2.6, Q7→HR 5.2 (Department Head AND HR Director).

**Your git commit message for UC-X:**
> UC-X Ask my documents: naive prompt blended IT and HR policies and hedged -> enforced single-source retrieval with document+section citations, an exact refusal template and a cross-document tie guard; verified on all 7 test questions

## CRAFT Loop Reflection
**Which CRAFT step was hardest across all UCs, and why?**
> Writing testable Enforcement rules. Stating intent was easy; turning each failure mode into a machine-checkable rule — e.g. "preserve BOTH approvers in clause 5.2" or "refuse cross-document ties" — was the hard part, and exactly where the naive prompt fails silently.

**What is the single most important thing you added manually to an agents.md that the AI did not generate on its own?**
> The multi-condition preservation rule in UC-0B: "Clause 5.2 requires approval from BOTH the Department Head AND the HR Director — dropping either approver is a condition drop, not an acceptable simplification. 'Requires approval' alone is wrong."

**Name one real task in your work where you will apply RICE + CRAFT within the next two weeks:**
> Drafting an internal SOP summariser that must preserve mandatory approval steps and escalation thresholds verbatim — applying the same completeness + condition-preservation enforcement so no compliance step is silently softened.