### PR TITLE
UC-0C Fix wrong aggregation: enforce ward-category scoped growth anal…

### DIFF
--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -1,18 +1,22 @@
 # agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
-
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
-
+  You are a municipal budget growth-analysis agent. Your operational boundary
+  is restricted to analyzing the supplied ward-budget CSV for one explicitly
+  specified ward and one explicitly specified category at a time.
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
-
+  Produce a verifiable per-period growth table for the requested ward and
+  category. Identify null actual_spend values before calculation, report the
+  reason from the notes column, and show the formula used alongside every
+  calculated result.
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
-
+  The agent may use only the supplied ward_budget.csv dataset and the explicitly
+  provided ward, category, and growth type. It may use the period, ward,
+  category, budgeted_amount, actual_spend, and notes columns. It must not invent
+  missing values or silently change the requested aggregation level.
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never aggregate across wards or categories. Refuse all-ward or cross-category aggregation."
+  - "Inspect and report every null actual_spend row before computing growth, including the reason from the notes column."
+  - "Never replace null actual_spend with zero or silently drop the row."
+  - "Every calculated output row must include the formula used alongside the result."
+  - "growth_type is mandatory. Never guess MoM or YoY."
+  - "Fail clearly if required columns, ward, or category are invalid."

--- a/uc-0c/app.py
+++ b/uc-0c/app.py
@@ -1,12 +1,178 @@
-"""
-UC-0C app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
-"""
 import argparse
+import csv
+
+REQUIRED_COLUMNS = {
+    "period",
+    "ward",
+    "category",
+    "budgeted_amount",
+    "actual_spend",
+    "notes",
+}
+
+
+def load_dataset(path):
+    with open(path, newline="", encoding="utf-8-sig") as file:
+        reader = csv.DictReader(file)
+
+        if reader.fieldnames is None:
+            raise ValueError("Input CSV has no header row.")
+
+        missing = REQUIRED_COLUMNS - set(reader.fieldnames)
+        if missing:
+            raise ValueError(
+                "Input CSV is missing required columns: "
+                + ", ".join(sorted(missing))
+            )
+
+        rows = list(reader)
+
+    null_rows = [
+        row for row in rows
+        if not row["actual_spend"].strip()
+    ]
+
+    print(f"Loaded {len(rows)} rows.")
+    print(f"Null actual_spend rows: {len(null_rows)}")
+
+    for row in null_rows:
+        print(
+            f"  {row['period']} | {row['ward']} | "
+            f"{row['category']} | {row['notes']}"
+        )
+
+    return rows
+
+
+def compute_growth(rows, ward, category, growth_type):
+    if not growth_type:
+        raise ValueError(
+            "growth_type is required. Specify MoM."
+        )
+
+    if growth_type != "MoM":
+        raise ValueError(
+            f"Unsupported growth_type: {growth_type}. "
+            "This UC supports MoM only."
+        )
+
+    filtered = [
+        row for row in rows
+        if row["ward"] == ward and row["category"] == category
+    ]
+
+    if not filtered:
+        raise ValueError(
+            f"No data found for ward '{ward}' "
+            f"and category '{category}'."
+        )
+
+    filtered.sort(key=lambda row: row["period"])
+
+    results = []
+    previous_actual = None
+
+    for row in filtered:
+        actual_text = row["actual_spend"].strip()
+
+        result = {
+            "period": row["period"],
+            "ward": row["ward"],
+            "category": row["category"],
+            "actual_spend": actual_text,
+            "growth_type": growth_type,
+            "growth_percent": "",
+            "formula": "",
+            "status": "",
+            "note": "",
+        }
+
+        if not actual_text:
+            result["status"] = "NULL_FLAGGED"
+            result["note"] = row["notes"]
+            result["formula"] = (
+                "Not computed because actual_spend is NULL"
+            )
+
+            results.append(result)
+
+            # A missing current value means we cannot use it
+            # as the previous value for the next calculation.
+            previous_actual = None
+            continue
+
+        current_actual = float(actual_text)
+
+        if previous_actual is None:
+            result["status"] = "BASELINE"
+            result["formula"] = (
+                "No previous valid period available for MoM"
+            )
+        else:
+            growth = (
+                (current_actual - previous_actual)
+                / previous_actual
+            ) * 100
+
+            result["growth_percent"] = f"{growth:.1f}"
+            result["status"] = "CALCULATED"
+            result["formula"] = (
+                f"(({current_actual:.1f} - "
+                f"{previous_actual:.1f}) / "
+                f"{previous_actual:.1f}) * 100"
+            )
+
+        results.append(result)
+        previous_actual = current_actual
+
+    return results
+
+
+def write_output(path, rows):
+    fieldnames = [
+        "period",
+        "ward",
+        "category",
+        "actual_spend",
+        "growth_type",
+        "growth_percent",
+        "formula",
+        "status",
+        "note",
+    ]
+
+    with open(path, "w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(
+        description="UC-0C ward budget growth analysis"
+    )
+
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--ward", required=True)
+    parser.add_argument("--category", required=True)
+    parser.add_argument("--growth-type", required=True)
+    parser.add_argument("--output", required=True)
+
+    args = parser.parse_args()
+
+    rows = load_dataset(args.input)
+
+    results = compute_growth(
+        rows,
+        args.ward,
+        args.category,
+        args.growth_type,
+    )
+
+    write_output(args.output, results)
+
+    print(f"Growth output written to {args.output}")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -1,16 +1,12 @@
 # skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
-
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
-
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: Reads the ward budget CSV, validates required columns, and reports the total null count and each null actual_spend row with its reason.
+    input: CSV file path.
+    output: Validated dataset and list of null actual_spend rows with their notes reasons.
+    error_handling: Fail if the file is missing, unreadable, or required columns are absent. Never replace null actual_spend values with zero.
+  - name: compute_growth
+    description: Computes growth for exactly one ward and one category using an explicitly specified growth type.
+    input: Dataset, ward, category, growth_type.
+    output: Per-period growth table with actual spend, growth result, formula, status, and null reason where applicable.
+    error_handling: Refuse missing or unsupported growth_type, invalid ward/category, or aggregation requests. Flag null rows instead of calculating them.


### PR DESCRIPTION
# UC-0C Fix wrong aggregation: enforce ward-category scoped growth analysis

## Summary

Fixes the UC-0C growth analysis implementation to prevent incorrect aggregation across wards and categories.

## Changes

* Enforces ward + category scoped growth analysis.
* Prevents unintended all-ward/all-category aggregation.
* Handles null `actual_spend` values explicitly instead of silently computing growth.
* Reports the null reason from the dataset notes.
* Includes the growth formula alongside computed results.
* Requires an explicit `--growth-type` instead of silently assuming MoM or YoY.
* Adds the required dataset loading and growth computation behavior in the agent/skills definitions.

## Validation

Verified the implementation against the UC-0C reference cases, including:

* Ward 1 – Kasba / Roads & Pothole Repair / 2024-07 → +33.1% MoM
* Ward 1 – Kasba / Roads & Pothole Repair / 2024-10 → −34.8% MoM
* Null actual-spend rows are flagged rather than used in calculations.
* Unscoped all-ward aggregation is refused.

## Commit

`f99981b` — UC-0C Fix wrong aggregation: enforce ward-category scoped growth analysis
