### PR TITLE
ci: allow fork PR checkout in pull_request_target workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - name: Check Commit Message Format
         run: |
           echo "=== Workflow version: v4-pull_request_target ==="
@@ -40,6 +41,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,7 +1,7 @@
 name: PR Checks
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
 env:
@@ -15,10 +15,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
       - name: Check Commit Message Format
         run: |
-          echo "=== Workflow version: v4-pull_request_target ==="
+          echo "=== Workflow version: v5-pull_request ==="
           # Accepts both formats from our docs:
           #   [UC-0A] Fix severity: missing keywords → added triggers
           #   UC-0B Generated agents.md and skills.md from README, implemented summariser
@@ -41,7 +40,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Problem

All participant (fork) PRs are failing both CI jobs on the PR Checks workflow with:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

`actions/checkout@v6` now hard-refuses to check out fork PR code inside a `pull_request_target` workflow unless the step explicitly opts in. Since this workflow intentionally runs from `main` (`pull_request_target`), every fork PR's `commit-lint` and `smoke-test` jobs fail at the checkout step before any validation runs.

## Fix

Added `allow-unsafe-pr-checkout: true` to both `actions/checkout@v6` steps (commit-lint and smoke-test).

Risk note (from https://gh.io/securely-using-pull_request_target): this opt-in is safe here because the workflow never executes code from the fork. The checkout is only used to read the head SHA's commits for linting and to `py_compile` the four UC scripts. Secrets are not exposed to fork code.

## After merge

Participant submission PRs will need their checks re-run (or a new push) so they validate against the fixed workflow.
