### PR TITLE
UC-0C Fix silent aggregation: no ward/category scope → enforced per-w…

### DIFF
--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -1,18 +1,16 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
-
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Municipal Budget and Expenditure Analyst responsible for granular, verifiable financial growth calculations across municipal wards and expenditure categories, preventing misleading cross-ward aggregations, and ensuring transparent audit trails for missing data.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  Produce a verifiable, granular per-ward per-category growth output table where each record specifies the period, budgeted amount, actual spend, calculated growth percentage, the exact formula applied, and explicit flags/reasons for any null values.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  Allowed inputs are the structured fields from the ward budget dataset: period (YYYY-MM), ward, category, budgeted_amount, actual_spend, and notes. Exclusions: Never aggregate across distinct wards or categories; never silently skip null rows; never impute missing values as 0.0 without explicit authorization.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never aggregate across wards or categories unless explicitly instructed; refuse any cross-ward aggregation requests with an explicit refusal message."
+  - "Flag every null row before computing and report the exact null reason from the 'notes' column; do not drop or silently impute null values."
+  - "Include the exact computational formula used (e.g. '(spend_current - spend_prior) / spend_prior * 100') in every computed output row alongside the result."
+  - "If growth-type is not explicitly specified (e.g. MoM or YoY), refuse execution and request explicit user specification; never guess or assume a default formula."
+  - "All growth percentage values must be formatted to one decimal place with a sign (e.g. '+33.1%', '-34.8%'), or 'N/A' when prior or current period is null."
+

--- a/uc-0c/app.py
+++ b/uc-0c/app.py
@@ -1,12 +1,203 @@
 """
-UC-0C app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0C — Number That Looks Right
+Budget Growth & Expenditure Analysis implementing RICE enforcement rules from agents.md and skills.md.
 """
 import argparse
+import csv
+import os
+import sys
+from typing import Dict, List, Tuple, Optional, Any
+
+
+def load_dataset(input_path: str) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """
+    Reads budget CSV dataset, validates required columns, and identifies all null actual_spend rows.
+    Returns: (records, null_report)
+    """
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Budget dataset file not found at: {input_path}")
+
+    required_columns = {"period", "ward", "category", "budgeted_amount", "actual_spend", "notes"}
+    records: List[Dict[str, Any]] = []
+    null_report: List[Dict[str, Any]] = []
+
+    with open(input_path, mode="r", encoding="utf-8", errors="replace") as infile:
+        reader = csv.DictReader(infile)
+        if not required_columns.issubset(set(reader.fieldnames or [])):
+            raise ValueError(f"CSV missing required columns: {required_columns - set(reader.fieldnames or [])}")
+
+        for row_idx, row in enumerate(reader, start=2):
+            raw_spend = row["actual_spend"].strip() if row["actual_spend"] is not None else ""
+            actual_spend: Optional[float] = None
+            if raw_spend != "":
+                try:
+                    actual_spend = float(raw_spend)
+                except ValueError:
+                    actual_spend = None
+
+            parsed_row = {
+                "period": row["period"].strip(),
+                "ward": row["ward"].strip(),
+                "category": row["category"].strip(),
+                "budgeted_amount": float(row["budgeted_amount"].strip()),
+                "actual_spend": actual_spend,
+                "notes": row.get("notes", "").strip(),
+            }
+            records.append(parsed_row)
+
+            if actual_spend is None:
+                null_report.append({
+                    "row_index": row_idx,
+                    "period": parsed_row["period"],
+                    "ward": parsed_row["ward"],
+                    "category": parsed_row["category"],
+                    "budgeted_amount": parsed_row["budgeted_amount"],
+                    "notes": parsed_row["notes"] or "Missing expenditure data",
+                })
+
+    return records, null_report
+
+
+def compute_growth(
+    records: List[Dict[str, Any]],
+    ward_filter: Optional[str] = None,
+    category_filter: Optional[str] = None,
+    growth_type: str = "MoM",
+) -> List[Dict[str, Any]]:
+    """
+    Computes growth strictly per-ward per-category without aggregating across groups.
+    """
+    if not growth_type:
+        raise ValueError("REFUSAL: Growth type must be explicitly specified (e.g. --growth-type MoM).")
+
+    if growth_type.upper() != "MOM":
+        raise NotImplementedError(f"Growth calculation for '{growth_type}' is not supported. Supported: MoM")
+
+    # Group records by (ward, category)
+    groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for r in records:
+        if ward_filter and ward_filter.upper() != "ALL" and r["ward"] != ward_filter:
+            continue
+        if category_filter and category_filter.upper() != "ALL" and r["category"] != category_filter:
+            continue
+        key = (r["ward"], r["category"])
+        groups.setdefault(key, []).append(r)
+
+    results: List[Dict[str, Any]] = []
+
+    for (ward, category), items in groups.items():
+        # Sort chronologically by period
+        items.sort(key=lambda x: x["period"])
+
+        prev_spend: Optional[float] = None
+        for item in items:
+            period = item["period"]
+            budgeted = item["budgeted_amount"]
+            curr_spend = item["actual_spend"]
+            notes = item["notes"]
+
+            if curr_spend is None:
+                growth_pct = "N/A"
+                formula = "Cannot compute: current period actual_spend is NULL"
+                flag = "NULL_SPEND"
+                out_spend_str = ""
+            elif prev_spend is None:
+                if items.index(item) == 0:
+                    growth_pct = "N/A"
+                    formula = "Baseline period: no prior period for MoM comparison"
+                    flag = ""
+                else:
+                    growth_pct = "N/A"
+                    formula = "Cannot compute: previous period actual_spend was NULL"
+                    flag = "PRIOR_PERIOD_NULL"
+                out_spend_str = f"{curr_spend:.1f}"
+            else:
+                if prev_spend == 0:
+                    growth_pct = "N/A"
+                    formula = "Undefined: division by zero (previous spend = 0)"
+                    flag = "ZERO_DIVISION"
+                else:
+                    growth_val = ((curr_spend - prev_spend) / prev_spend) * 100.0
+                    sign = "+" if growth_val > 0 else ""
+                    growth_pct = f"{sign}{growth_val:.1f}%"
+                    formula = f"({curr_spend:.1f} - {prev_spend:.1f}) / {prev_spend:.1f} * 100"
+                    flag = ""
+                out_spend_str = f"{curr_spend:.1f}"
+
+            results.append({
+                "period": period,
+                "ward": ward,
+                "category": category,
+                "budgeted_amount": f"{budgeted:.1f}",
+                "actual_spend": out_spend_str,
+                "growth_type": growth_type,
+                "growth_pct": growth_pct,
+                "formula": formula,
+                "flag": flag,
+                "notes": notes,
+            })
+
+            prev_spend = curr_spend
+
+    return results
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0C Municipal Budget Growth Analyzer")
+    parser.add_argument("--input", default="../data/budget/ward_budget.csv", help="Path to ward_budget.csv")
+    parser.add_argument("--ward", default="Ward 1 – Kasba", help="Ward name or 'ALL'")
+    parser.add_argument("--category", default="Roads & Pothole Repair", help="Category name or 'ALL'")
+    parser.add_argument("--growth-type", default="MoM", help="Growth calculation type (e.g. MoM)")
+    parser.add_argument("--aggregate-all-wards", action="store_true", help="Flag that triggers refusal for cross-ward aggregation")
+    parser.add_argument("--output", default="growth_output.csv", help="Path to output growth CSV")
+    args = parser.parse_args()
+
+    # Rule 1 Enforcement: Refuse cross-ward aggregation requests
+    if args.aggregate_all_wards:
+        print("REFUSAL: Cross-ward aggregation is strictly disallowed to prevent misleading data masking. Growth must be analyzed per-ward per-category.", file=sys.stderr)
+        sys.exit(1)
+
+    # Rule 4 Enforcement: Refuse if growth-type missing
+    if not args.growth_type:
+        print("REFUSAL: Growth type not specified. Please supply --growth-type (e.g. MoM).", file=sys.stderr)
+        sys.exit(1)
+
+    records, null_report = load_dataset(args.input)
+
+    # Rule 2 Enforcement: Audit and display all null rows before computing
+    print(f"=== PRE-COMPUTATION NULL AUDIT REPORT ({len(null_report)} null rows detected) ===")
+    for n in null_report:
+        print(f"  • Period: {n['period']} | Ward: {n['ward']} | Category: {n['category']} | Reason: {n['notes']}")
+    print("=" * 70)
+
+    results = compute_growth(
+        records=records,
+        ward_filter=args.ward,
+        category_filter=args.category,
+        growth_type=args.growth_type,
+    )
+
+    fieldnames = [
+        "period",
+        "ward",
+        "category",
+        "budgeted_amount",
+        "actual_spend",
+        "growth_type",
+        "growth_pct",
+        "formula",
+        "flag",
+        "notes",
+    ]
+
+    with open(args.output, mode="w", encoding="utf-8", newline="") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
+
+    print(f"Done. Per-ward per-category growth table written to: {args.output}")
+
 
 if __name__ == "__main__":
     main()
+

--- a/uc-0c/growth_output.csv
+++ b/uc-0c/growth_output.csv
@@ -1,0 +1,13 @@
+period,ward,category,budgeted_amount,actual_spend,growth_type,growth_pct,formula,flag,notes
+2024-01,Ward 1 – Kasba,Roads & Pothole Repair,13.0,13.3,MoM,N/A,Baseline period: no prior period for MoM comparison,,
+2024-02,Ward 1 – Kasba,Roads & Pothole Repair,13.0,12.2,MoM,-8.3%,(12.2 - 13.3) / 13.3 * 100,,
+2024-03,Ward 1 – Kasba,Roads & Pothole Repair,13.0,12.3,MoM,+0.8%,(12.3 - 12.2) / 12.2 * 100,,
+2024-04,Ward 1 – Kasba,Roads & Pothole Repair,13.0,13.4,MoM,+8.9%,(13.4 - 12.3) / 12.3 * 100,,
+2024-05,Ward 1 – Kasba,Roads & Pothole Repair,13.0,14.1,MoM,+5.2%,(14.1 - 13.4) / 13.4 * 100,,
+2024-06,Ward 1 – Kasba,Roads & Pothole Repair,13.0,14.8,MoM,+5.0%,(14.8 - 14.1) / 14.1 * 100,,
+2024-07,Ward 1 – Kasba,Roads & Pothole Repair,13.0,19.7,MoM,+33.1%,(19.7 - 14.8) / 14.8 * 100,,
+2024-08,Ward 1 – Kasba,Roads & Pothole Repair,13.0,20.2,MoM,+2.5%,(20.2 - 19.7) / 19.7 * 100,,
+2024-09,Ward 1 – Kasba,Roads & Pothole Repair,13.0,20.1,MoM,-0.5%,(20.1 - 20.2) / 20.2 * 100,,
+2024-10,Ward 1 – Kasba,Roads & Pothole Repair,13.0,13.1,MoM,-34.8%,(13.1 - 20.1) / 20.1 * 100,,
+2024-11,Ward 1 – Kasba,Roads & Pothole Repair,13.0,14.2,MoM,+8.4%,(14.2 - 13.1) / 13.1 * 100,,
+2024-12,Ward 1 – Kasba,Roads & Pothole Repair,13.0,12.7,MoM,-10.6%,(12.7 - 14.2) / 14.2 * 100,,

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -1,16 +1,13 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
-
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: Ingests ward budget CSV data, validates required columns, identifies all null rows, and generates a pre-computation null audit report.
+    input: input_path (str - path to ward_budget.csv)
+    output: tuple of (records: list of dicts, null_report: list of dicts describing null rows and notes)
+    error_handling: Raises ValueError if required columns are missing; safely records unparseable values as null with warning flags.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: compute_growth
+    description: Computes period-over-period expenditure growth strictly scoped within a single ward and category, returning formatted records with formulas and null flags.
+    input: records (list of dicts), ward (str), category (str), growth_type (str - e.g. 'MoM' or 'YoY')
+    output: list of dicts containing {period, ward, category, budgeted_amount, actual_spend, growth_pct, formula, flag, notes}
+    error_handling: Refuses cross-ward aggregation; flags periods where actual_spend or previous period spend is null as 'NULL_SPEND' or 'PRIOR_NULL'.
+


### PR DESCRIPTION
## UC-0C — Number That Looks Right

- **Failure Mode:** Silent aggregation and null skipping (naive prompt produced a single aggregated number across all wards and silently ignored the 5 null rows).
- **Enforcement Fix:** Enforced strict per-ward per-category scoping, formula transparency in every output row, refusal of cross-ward aggregation, and pre-computation null auditing with reasons from `notes`.
- **Rule from agents.md:**
  > `"Never aggregate across wards or categories unless explicitly instructed; refuse any cross-ward aggregation requests with an explicit refusal message."`
- **Verification:** Verified reference figures (`Ward 1 Roads` +33.1% in July, −34.8% in October) and confirmed all 5 null rows are flagged rather than skipped.
- **Commit:** `UC-0C Fix silent aggregation: no ward/category scope → enforced per-ward per-category only`
