### PR TITLE
[Pune] PSergio984 — Vibe Coding Submission

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,31 @@
 # agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  A deterministic rule-based classifier agent for citizen complaints filed
+  against the Pune municipal system. It reads one complaint row at a time and
+  assigns exactly one category, one priority, a one-sentence justification,
+  and an ambiguity flag. It makes no network calls and uses no external
+  knowledge beyond the description text in the row itself.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is a CSV with one row per input complaint containing:
+  complaint_id (echoed verbatim), category (an exact string from the allowed
+  taxonomy), priority (Urgent/Standard/Low), reason (one sentence quoting
+  words that appear in the description), flag (NEEDS_REVIEW or blank).
+  Verifiable: every category must be in the allowed list; every description
+  containing a severity keyword must yield priority=Urgent.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only these row fields: complaint_id and description.
+  It must NOT use date_raised, city, ward, location, reported_by, or days_open
+  for classification decisions, and must not invent sub-categories outside
+  the fixed taxonomy.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other"
+  - "Priority must be Urgent if description contains any of: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse"
+  - "Priority is Low only if the description explicitly contains minor/cosmetic/trivial language and no severity keyword; otherwise Standard"
+  - "Every output row must include a reason field citing specific words from the description"
+  - "If two or more distinct categories match, keep the highest-precedence match but set flag: NEEDS_REVIEW"
+  - "Refusal condition: If no category cue can be determined from the description alone, output category: Other and flag: NEEDS_REVIEW"
+  - "A malformed, empty, or null row must never crash the batch run; it yields Other / NEEDS_REVIEW"

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,34 +1,145 @@
 """
 UC-0A — Complaint Classifier
-Starter file. Build this using the RICE → agents.md → skills.md → CRAFT workflow.
+
+Deterministic, rule-based classifier for civic complaints.
+Enforcement rules mirror agents.md; skill contracts mirror skills.md.
+
+Usage:
+    python classifier.py --input ../data/city-test-files/test_pune.csv \
+        --output results_pune.csv
 """
 import argparse
 import csv
+import re
+
+CATEGORIES = [
+    "Pothole", "Flooding", "Streetlight", "Waste", "Noise",
+    "Road Damage", "Heritage Damage", "Heat Hazard", "Drain Blockage",
+    "Other",
+]
+
+SEVERITY_KEYWORDS = [
+    "injury", "child", "school", "hospital",
+    "ambulance", "fire", "hazard", "fell", "collapse",
+]
+LOW_KEYWORDS = ["minor", "cosmetic", "trivial"]
+
+# Cue phrases per category. Ordered: earlier entries win ties.
+CATEGORY_CUES = [
+    ("Heritage Damage", [r"heritage"]),
+    ("Pothole", [r"pothole"]),
+    ("Flooding", [r"flood", r"inundat", r"knee-?deep water", r"waterlog"]),
+    ("Drain Blockage", [r"drain\s+block", r"clogged drain", r"blocked drain"]),
+    ("Streetlight", [r"streetlight", r"street light", r"lights?\s+(out|flicker|sparking)", r"lamp post"]),
+    ("Waste", [r"garbage", r"waste", r"trash", r"dump(ed|ing)?\b", r"dead animal", r"bins?"]),
+    ("Noise", [r"\bnoise\b", r"music", r"loudspeaker"]),
+    ("Road Damage", [r"road\s+(surface|crack|sink)", r"footpath", r"sinking", r"upturned"]),
+    ("Heat Hazard", [r"heat\s?(wave|hazard|stroke)", r"extreme heat"]),
+]
+
+
+def _find_cue_matches(text):
+    """Return list of (category, matched_term) preserving CATEGORY_CUES order."""
+    matches = []
+    lowered = text.lower()
+    for category, patterns in CATEGORY_CUES:
+        for pattern in patterns:
+            m = re.search(pattern, lowered)
+            if m:
+                start = max(0, m.start() - 15)
+                end = min(len(lowered), m.end() + 15)
+                snippet = lowered[start:end].strip()
+                matches.append((category, snippet))
+                break
+    return matches
+
 
 def classify_complaint(row: dict) -> dict:
     """
     Classify a single complaint row.
-    Returns: dict with keys: complaint_id, category, priority, reason, flag
-    
-    TODO: Build this using your AI tool guided by your agents.md and skills.md.
-    Your RICE enforcement rules must be reflected in this function's behaviour.
+    Returns dict with keys: complaint_id, category, priority, reason, flag
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    complaint_id = (row.get("complaint_id") or "").strip()
+    description = row.get("description") or ""
+    if not isinstance(description, str):
+        description = str(description)
+
+    cue_matches = _find_cue_matches(description)
+    if not cue_matches:
+        return {
+            "complaint_id": complaint_id,
+            "category": "Other",
+            "priority": _priority(description),
+            "reason": (
+                "No known category cue found in description "
+                f"'{description[:60]}'" if description
+                else "Description missing or empty"
+            ),
+            "flag": "NEEDS_REVIEW",
+        }
+
+    distinct = {c for c, _ in cue_matches}
+    category, snippet = cue_matches[0]
+    ambiguous = len(distinct) > 1
+    if ambiguous:
+        others = sorted(distinct - {category})
+        reason = (
+            f"Mentions '{snippet}' suggesting {category}, but also "
+            f"{', '.join(others)} cues"
+        )
+    else:
+        reason = f"Mentions '{snippet}' which maps to {category}"
+
+    return {
+        "complaint_id": complaint_id,
+        "category": category,
+        "priority": _priority(description),
+        "reason": reason,
+        "flag": "NEEDS_REVIEW" if ambiguous else "",
+    }
+
+
+def _priority(description: str) -> str:
+    lowered = (description or "").lower()
+    if any(k in lowered for k in SEVERITY_KEYWORDS):
+        return "Urgent"
+    if any(k in lowered for k in LOW_KEYWORDS):
+        return "Low"
+    return "Standard"
 
 
 def batch_classify(input_path: str, output_path: str):
     """
     Read input CSV, classify each row, write results CSV.
-    
-    TODO: Build this using your AI tool.
-    Must: flag nulls, not crash on bad rows, produce output even if some rows fail.
+    Flags bad rows as NEEDS_REVIEW instead of crashing; always produces output.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    with open(input_path, newline="", encoding="utf-8-sig") as fin:
+        reader = csv.DictReader(fin)
+        rows = list(reader)
+
+    results = []
+    for row in rows:
+        try:
+            results.append(classify_complaint(row))
+        except Exception:  # noqa: BLE001 - never crash the batch
+            results.append({
+                "complaint_id": (row.get("complaint_id") or "").strip(),
+                "category": "Other",
+                "priority": "Standard",
+                "reason": "Classifier error on this row",
+                "flag": "NEEDS_REVIEW",
+            })
+
+    fieldnames = ["complaint_id", "category", "priority", "reason", "flag"]
+    with open(output_path, "w", newline="", encoding="utf-8") as fout:
+        writer = csv.DictWriter(fout, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="UC-0A Complaint Classifier")
-    parser.add_argument("--input",  required=True, help="Path to test_[city].csv")
+    parser.add_argument("--input", required=True, help="Path to test_[city].csv")
     parser.add_argument("--output", required=True, help="Path to write results CSV")
     args = parser.parse_args()
     batch_classify(args.input, args.output)

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -26,30 +26,32 @@ LOW_KEYWORDS = ["minor", "cosmetic", "trivial"]
 
 # Cue phrases per category. Ordered: earlier entries win ties.
 CATEGORY_CUES = [
-    ("Heritage Damage", [r"heritage"]),
-    ("Pothole", [r"pothole"]),
-    ("Flooding", [r"flood", r"inundat", r"knee-?deep water", r"waterlog"]),
-    ("Drain Blockage", [r"drain\s+block", r"clogged drain", r"blocked drain"]),
-    ("Streetlight", [r"streetlight", r"street light", r"lights?\s+(out|flicker|sparking)", r"lamp post"]),
-    ("Waste", [r"garbage", r"waste", r"trash", r"dump(ed|ing)?\b", r"dead animal", r"bins?"]),
-    ("Noise", [r"\bnoise\b", r"music", r"loudspeaker"]),
-    ("Road Damage", [r"road\s+(surface|crack|sink)", r"footpath", r"sinking", r"upturned"]),
-    ("Heat Hazard", [r"heat\s?(wave|hazard|stroke)", r"extreme heat"]),
+    ("Heritage Damage", [r"\bheritage\b"]),
+    ("Pothole", [r"\bpotholes?\b"]),
+    ("Flooding", [r"\bflood", r"\binundat", r"\bknee-?deep water\b", r"\bwaterlog"]),
+    ("Drain Blockage", [r"\bdrain(s)?\s+block", r"\bclogged drain\b", r"\bblocked drain\b"]),
+    ("Streetlight", [r"\bstreetlights?\b", r"\bstreet lights?\b", r"\blights?\s+(out|flickering|sparking)\b", r"\blamp posts?\b"]),
+    ("Waste", [r"\bgarbage\b", r"\bwaste\b", r"\btrash\b", r"\bdump(ed|ing)?\b", r"\bdead animal\b", r"\bbins?\b"]),
+    ("Noise", [r"\bnoise\b", r"\bmusic\b", r"\bloudspeakers?\b"]),
+    ("Road Damage", [r"\broad\s+(surface|crack|sinking)", r"\bfootpaths?\b", r"\bsinking\b", r"\bupturned\b"]),
+    ("Heat Hazard", [r"\bheat\s?(wave|hazard|stroke)\b", r"\bextreme heat\b"]),
 ]
 
 
 def _find_cue_matches(text):
-    """Return list of (category, matched_term) preserving CATEGORY_CUES order."""
+    """Return list of (category, quoted_words) preserving CATEGORY_CUES order."""
     matches = []
     lowered = text.lower()
     for category, patterns in CATEGORY_CUES:
         for pattern in patterns:
             m = re.search(pattern, lowered)
             if m:
-                start = max(0, m.start() - 15)
-                end = min(len(lowered), m.end() + 15)
-                snippet = lowered[start:end].strip()
-                matches.append((category, snippet))
+                start, end = m.start(), m.end()
+                while start > 0 and lowered[start - 1].isalnum():
+                    start -= 1
+                while end < len(lowered) and lowered[end].isalnum():
+                    end += 1
+                matches.append((category, text[start:end]))
                 break
     return matches
 
@@ -99,11 +101,20 @@ def classify_complaint(row: dict) -> dict:
     }
 
 
+def _matches_word(text: str, keywords) -> bool:
+    """Whole-word match allowing plural/verb inflections (child->children)."""
+    for keyword in keywords:
+        if re.search(r"\b" + re.escape(keyword) + r"(s|es|ed|d|ing|ren)?\b",
+                     text):
+            return True
+    return False
+
+
 def _priority(description: str) -> str:
     lowered = (description or "").lower()
-    if any(k in lowered for k in SEVERITY_KEYWORDS):
+    if _matches_word(lowered, SEVERITY_KEYWORDS):
         return "Urgent"
-    if any(k in lowered for k in LOW_KEYWORDS):
+    if _matches_word(lowered, LOW_KEYWORDS):
         return "Low"
     return "Standard"
 

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,16 +1,16 @@
 complaint_id,category,priority,reason,flag
-PM-202401,Pothole,Standard,Mentions 'large pothole 60cm wide caus' which maps to Pothole,
-PM-202402,Pothole,Urgent,Mentions 'deep pothole near bus stop.' which maps to Pothole,
-PM-202406,Flooding,Standard,Mentions 'underpass flooded knee-deep af' which maps to Flooding,
-PM-202408,Flooding,Standard,"Mentions 'bus stand flooded. passengers' suggesting Flooding, but also Drain Blockage cues",NEEDS_REVIEW
-PM-202410,Streetlight,Standard,Mentions 'ee consecutive streetlights out for 10 da' which maps to Streetlight,
-PM-202411,Streetlight,Urgent,Mentions 'streetlight flickering and' which maps to Streetlight,
-PM-202413,Waste,Standard,Mentions 'overflowing garbage bins near vege' which maps to Waste,
-PM-202418,Noise,Standard,Mentions 'venue playing music past midnight' which maps to Noise,
-PM-202419,Road Damage,Standard,Mentions 'road surface cracked and si' which maps to Road Damage,
+PM-202401,Pothole,Standard,Mentions 'pothole' which maps to Pothole,
+PM-202402,Pothole,Urgent,Mentions 'pothole' which maps to Pothole,
+PM-202406,Flooding,Standard,Mentions 'flooded' which maps to Flooding,
+PM-202408,Flooding,Standard,"Mentions 'flooded' suggesting Flooding, but also Drain Blockage cues",NEEDS_REVIEW
+PM-202410,Streetlight,Standard,Mentions 'streetlights' which maps to Streetlight,
+PM-202411,Streetlight,Urgent,Mentions 'Streetlight' which maps to Streetlight,
+PM-202413,Waste,Standard,Mentions 'garbage' which maps to Waste,
+PM-202418,Noise,Standard,Mentions 'music' which maps to Noise,
+PM-202419,Road Damage,Standard,Mentions 'Road surface' which maps to Road Damage,
 PM-202420,Other,Urgent,No known category cue found in description 'Manhole cover missing. Risk of serious injury to cyclists.',NEEDS_REVIEW
-PM-202427,Flooding,Standard,Mentions 'ridge approach floods in 30mins of' which maps to Flooding,
-PM-202428,Waste,Standard,Mentions 'dead animal not removed fo' which maps to Waste,
-PM-202430,Heritage Damage,Standard,"Mentions 'heritage street, lights' suggesting Heritage Damage, but also Streetlight cues",NEEDS_REVIEW
-PM-202433,Waste,Standard,Mentions 'bulk waste from apartment' which maps to Waste,
-PM-202446,Road Damage,Urgent,Mentions 'footpath tiles broken a' which maps to Road Damage,
+PM-202427,Flooding,Standard,Mentions 'floods' which maps to Flooding,
+PM-202428,Waste,Standard,Mentions 'Dead animal' which maps to Waste,
+PM-202430,Heritage Damage,Standard,"Mentions 'Heritage' suggesting Heritage Damage, but also Streetlight cues",NEEDS_REVIEW
+PM-202433,Waste,Standard,Mentions 'waste' which maps to Waste,
+PM-202446,Road Damage,Urgent,Mentions 'Footpath' which maps to Road Damage,

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+PM-202401,Pothole,Standard,Mentions 'large pothole 60cm wide caus' which maps to Pothole,
+PM-202402,Pothole,Urgent,Mentions 'deep pothole near bus stop.' which maps to Pothole,
+PM-202406,Flooding,Standard,Mentions 'underpass flooded knee-deep af' which maps to Flooding,
+PM-202408,Flooding,Standard,"Mentions 'bus stand flooded. passengers' suggesting Flooding, but also Drain Blockage cues",NEEDS_REVIEW
+PM-202410,Streetlight,Standard,Mentions 'ee consecutive streetlights out for 10 da' which maps to Streetlight,
+PM-202411,Streetlight,Urgent,Mentions 'streetlight flickering and' which maps to Streetlight,
+PM-202413,Waste,Standard,Mentions 'overflowing garbage bins near vege' which maps to Waste,
+PM-202418,Noise,Standard,Mentions 'venue playing music past midnight' which maps to Noise,
+PM-202419,Road Damage,Standard,Mentions 'road surface cracked and si' which maps to Road Damage,
+PM-202420,Other,Urgent,No known category cue found in description 'Manhole cover missing. Risk of serious injury to cyclists.',NEEDS_REVIEW
+PM-202427,Flooding,Standard,Mentions 'ridge approach floods in 30mins of' which maps to Flooding,
+PM-202428,Waste,Standard,Mentions 'dead animal not removed fo' which maps to Waste,
+PM-202430,Heritage Damage,Standard,"Mentions 'heritage street, lights' suggesting Heritage Damage, but also Streetlight cues",NEEDS_REVIEW
+PM-202433,Waste,Standard,Mentions 'bulk waste from apartment' which maps to Waste,
+PM-202446,Road Damage,Urgent,Mentions 'footpath tiles broken a' which maps to Road Damage,

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,14 @@
 # skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: Assigns one civic complaint a category, priority, cited reason, and ambiguity flag using deterministic keyword rules.
+    input: dict with keys complaint_id (str) and description (str); may contain extra fields which are ignored.
+    output: dict with keys complaint_id (str), category (one of the ten exact taxonomy strings), priority (Urgent | Standard | Low), reason (one sentence quoting words from the description), flag ("NEEDS_REVIEW" or empty string).
+    error_handling: Never raises. Missing/null/empty description returns category Other with flag NEEDS_REVIEW; multi-category matches resolve to the highest-precedence category but set flag NEEDS_REVIEW.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: Reads an input CSV of complaints, applies classify_complaint to each row, and writes a results CSV.
+    input: Path to a UTF-8 CSV with a header row including complaint_id and description columns; plus the output path.
+    output: Writes a UTF-8 CSV with columns complaint_id, category, priority, reason, flag — one row per input row, same order.
+    error_handling: A per-row exception is caught and recorded as Other / Standard / NEEDS_REVIEW instead of aborting the batch; the output file is always produced even if some rows fail.

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -5,7 +5,7 @@ skills:
     description: Assigns one civic complaint a category, priority, cited reason, and ambiguity flag using deterministic keyword rules.
     input: dict with keys complaint_id (str) and description (str); may contain extra fields which are ignored.
     output: dict with keys complaint_id (str), category (one of the ten exact taxonomy strings), priority (Urgent | Standard | Low), reason (one sentence quoting words from the description), flag ("NEEDS_REVIEW" or empty string).
-    error_handling: Never raises. Missing/null/empty description returns category Other with flag NEEDS_REVIEW; multi-category matches resolve to the highest-precedence category but set flag NEEDS_REVIEW.
+    error_handling: Does not raise for dict rows; missing/null/empty description returns category Other with flag NEEDS_REVIEW; multi-category matches resolve to the highest-precedence category but set flag NEEDS_REVIEW.
 
   - name: batch_classify
     description: Reads an input CSV of complaints, applies classify_complaint to each row, and writes a results CSV.

--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,29 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0B Policy Summarizer
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  A deterministic extractive summarizer for municipal HR policy documents.
+  It reads a structured numbered policy and produces a summary in which every
+  numbered clause is present, obligations keep their original binding verbs,
+  and multi-condition rules keep every condition. It does not paraphrase,
+  interpret, or extend the source.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output contains one line per source clause number (e.g. "5.2"),
+  where each line's content comes only from that clause's own sentences.
+  Verifiable: (a) clause-number set of summary equals clause-number set of
+  source; (b) no alphabetic word appears in a clause line that is not in the
+  source document; (c) for every clause, all obligation/condition sentences
+  appear either compressed to zero loss or quoted verbatim with a flag.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the text of the input .txt file. It must NOT use
+  outside knowledge of "standard practice", other organisations' policies, or
+  general HR conventions, and must not add rationale, examples, or advice.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause present in the source must be present in the summary"
+  - "Multi-condition obligations must preserve ALL conditions — never drop one silently (e.g. 5.2 keeps both Department Head AND HR Director)"
+  - "Binding verbs are copied verbatim — never softened (must stays must; 'not permitted under any circumstances' keeps its full strength)"
+  - "Never add information not present in the source document"
+  - "If a clause cannot be summarised without meaning loss — quote it verbatim and flag it with [QUOTED VERBATIM]"
+  - "Refusal condition: if the input contains no numbered clauses, output exactly 'No numbered clauses found in source document.' instead of guessing a summary"

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,104 @@
 """
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0B — Summary That Changes Meaning
+
+Extractive policy summarizer: preserves every numbered clause, every binding
+verb, and every condition verbatim. Adds nothing, drops no obligations.
+Enforcement rules mirror agents.md; skill contracts mirror skills.md.
+
+Usage:
+    python app.py --input ../data/policy-documents/policy_hr_leave.txt \
+        --output summary_hr_leave.txt
 """
 import argparse
+import re
+from collections import OrderedDict
+
+CLAUSE_RE = re.compile(r"^\s*(\d+\.\d+)\s+(.*)$")
+SECTION_RE = re.compile(r"^\s*(\d+)\.\s+([A-Z][A-Z &()\-]+)\s*$")
+DIVIDER_RE = re.compile(r"^[\s═─=_-]+$")
+
+# A sentence is kept only if it carries an obligation, condition, negation,
+# entitlement, or boundary. Everything else is descriptive filler.
+KEEP_RE = re.compile(
+    r"\b(must|shall|will|may|requires?|required|entitled|forfeit\w*|cannot|"
+    r"not\s+permitted|not\s+valid|not\s+sufficient|not\s+apply|not\s+count|"
+    r"regardless|within|before|after|unless|exceeding|maximum|minimum|"
+    r"only|at\s+least|under\s+any\s+circumstances|if\b|or\b|and\b)\b",
+    re.IGNORECASE,
+)
+
+FLAG = "[QUOTED VERBATIM - summarisation risked meaning loss]"
+
+
+def _sentences(text):
+    normalized = re.sub(r"\s+", " ", text).strip()
+    return re.split(r"(?<=[.!?])\s+", normalized) if normalized else []
+
+
+def _parse_clauses(raw_text):
+    """Walk the document once, attaching wrapped lines to their clause."""
+    clauses = OrderedDict()
+    current = None
+    for line in raw_text.splitlines():
+        if DIVIDER_RE.match(line):
+            continue  # box-drawing section dividers are not clause content
+        m = CLAUSE_RE.match(line)
+        if m:
+            current = m.group(1)
+            clauses[current] = m.group(2)
+        elif current is not None and line.strip() and \
+                not SECTION_RE.match(line):
+            clauses[current] += " " + line.strip()
+    return clauses
+
+
+def retrieve_policy(path: str) -> dict:
+    """Load a .txt policy file, return {clause_number: clause_text}."""
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    return _parse_clauses(raw)
+
+
+def summarize_policy(clauses: dict) -> str:
+    """Produce a compliant summary: every clause present, conditions intact."""
+    if not clauses:
+        return "No numbered clauses found in source document."
+
+    lines = [
+        "SUMMARY - EMPLOYEE LEAVE POLICY (extractive)",
+        "All numbered clauses present; obligations and multi-condition",
+        "rules preserved word-for-word from the source document.",
+        "",
+    ]
+    for num in sorted(clauses, key=lambda k: tuple(map(int, k.split(".")))):
+        text = clauses[num]
+        kept = [s for s in _sentences(text) if KEEP_RE.search(s)]
+        if not kept or len(kept) < len(_sentences(text)):
+            # Anything filtered (or nothing filterable safely) -> quote whole
+            # clause verbatim and flag rather than risk a dropped condition.
+            body = re.sub(r"\s+", " ", text)
+            lines.append(f"{num} {body}")
+            lines.append(f"   {FLAG}")
+        else:
+            body = " ".join(kept)
+            lines.append(f"{num} {body}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0B Policy Summarizer")
+    parser.add_argument("--input", required=True,
+                        help="Path to policy .txt file")
+    parser.add_argument("--output", required=True,
+                        help="Path to write summary .txt")
+    args = parser.parse_args()
+    clauses = retrieve_policy(args.input)
+    summary = summarize_policy(clauses)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(summary)
+    print(f"Done. Summary written to {args.output}")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -13,9 +13,9 @@ import argparse
 import re
 from collections import OrderedDict
 
-CLAUSE_RE = re.compile(r"^\s*(\d+\.\d+)\s+(.*)$")
-SECTION_RE = re.compile(r"^\s*(\d+)\.\s+([A-Z][A-Z &()\-]+)\s*$")
-DIVIDER_RE = re.compile(r"^[\s═─=_-]+$")
+CLAUSE_RE = re.compile(r"^(\d+\.\d+)\s+(.*)$")  # anchored: no indent
+SECTION_RE = re.compile(r"^\s*(\d+)\.\s+([A-Za-z][A-Za-z &()\-]+)\s*$")
+DIVIDER_RE = re.compile(r"^[\s═─=_\u2013\u2014-]+$")
 
 # A sentence is kept only if it carries an obligation, condition, negation,
 # entitlement, or boundary. Everything else is descriptive filler.
@@ -23,7 +23,16 @@ KEEP_RE = re.compile(
     r"\b(must|shall|will|may|requires?|required|entitled|forfeit\w*|cannot|"
     r"not\s+permitted|not\s+valid|not\s+sufficient|not\s+apply|not\s+count|"
     r"regardless|within|before|after|unless|exceeding|maximum|minimum|"
-    r"only|at\s+least|under\s+any\s+circumstances|if\b|or\b|and\b)\b",
+    r"only|at\s+least|under\s+any\s+circumstances)\b",
+    re.IGNORECASE,
+)
+
+# Stronger subset: if dropping such a sentence would lose an obligation,
+# the whole clause is quoted verbatim instead of summarised.
+OBLIGATION_RE = re.compile(
+    r"\b(must|shall|requires?|required|entitled|forfeit\w*|cannot|"
+    r"not\s+permitted|not\s+valid|not\s+sufficient|regardless|exceeding|"
+    r"maximum|at\s+least|under\s+any\s+circumstances)\b",
     re.IGNORECASE,
 )
 
@@ -45,7 +54,11 @@ def _parse_clauses(raw_text):
         m = CLAUSE_RE.match(line)
         if m:
             current = m.group(1)
-            clauses[current] = m.group(2)
+            if current in clauses:
+                # duplicate numbering (annex/amendment): merge, never lose text
+                clauses[current] += " " + m.group(2)
+            else:
+                clauses[current] = m.group(2)
         elif current is not None and line.strip() and \
                 not SECTION_RE.match(line):
             clauses[current] += " " + line.strip()
@@ -72,16 +85,20 @@ def summarize_policy(clauses: dict) -> str:
     ]
     for num in sorted(clauses, key=lambda k: tuple(map(int, k.split(".")))):
         text = clauses[num]
-        kept = [s for s in _sentences(text) if KEEP_RE.search(s)]
-        if not kept or len(kept) < len(_sentences(text)):
-            # Anything filtered (or nothing filterable safely) -> quote whole
-            # clause verbatim and flag rather than risk a dropped condition.
+        sentences = _sentences(text)
+        kept = [s for s in sentences if KEEP_RE.search(s)]
+        lost = any(OBLIGATION_RE.search(s) and not KEEP_RE.search(s)
+                   for s in sentences)
+        if not kept or lost:
+            # Nothing keepable, or a sentence carrying an obligation would be
+            # dropped: the clause cannot be summarised without meaning loss,
+            # so quote it verbatim and flag it.
             body = re.sub(r"\s+", " ", text)
             lines.append(f"{num} {body}")
             lines.append(f"   {FLAG}")
         else:
-            body = " ".join(kept)
-            lines.append(f"{num} {body}")
+            # Real compression: obligations kept, pure filler dropped.
+            lines.append(f"{num} " + " ".join(kept))
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,14 @@
 # skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Loads a .txt policy file and returns its content as structured numbered sections keyed by clause number.
+    input: Path to a UTF-8 .txt policy document whose clauses are numbered N.N at line starts, with wrapped continuation lines beneath.
+    output: Ordered dict mapping clause number strings ("2.3") to full clause text (wrapped lines joined); section headers excluded.
+    error_handling: Missing or unreadable file raises OSError to the caller; an empty or header-only file yields an empty dict rather than crashing.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Produces a compliant summary in which every clause number from the input appears, with obligation and condition sentences preserved verbatim.
+    input: Dict mapping clause numbers to clause text, as returned by retrieve_policy (may also be built by any equivalent parser).
+    output: UTF-8 summary string with one "N.N ..." line per clause; clauses whose sentences could not be safely filtered carry a [QUOTED VERBATIM] flag on the following line; empty input yields the exact refusal line "No numbered clauses found in source document."
+    error_handling: Never raises for dict input; missing keys, None values, or non-string clause text are treated as empty and fall through to the verbatim/refusal path.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -3,9 +3,9 @@ All numbered clauses present; obligations and multi-condition
 rules preserved word-for-word from the source document.
 
 1.1 This policy governs all leave entitlements for permanent and contractual employees of the City Municipal Corporation (CMC).
-
-1.2 This policy does not apply to daily wage workers or consultants. Those categories are governed by their respective contracts.
    [QUOTED VERBATIM - summarisation risked meaning loss]
+
+1.2 This policy does not apply to daily wage workers or consultants.
 
 2.1 Each permanent employee is entitled to 18 days of paid annual leave per calendar year.
 
@@ -33,6 +33,7 @@ rules preserved word-for-word from the source document.
 4.1 Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
 
 4.2 For a third or subsequent child, maternity leave is 12 weeks paid.
+   [QUOTED VERBATIM - summarisation risked meaning loss]
 
 4.3 Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
 

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,63 @@
+SUMMARY - EMPLOYEE LEAVE POLICY (extractive)
+All numbered clauses present; obligations and multi-condition
+rules preserved word-for-word from the source document.
+
+1.1 This policy governs all leave entitlements for permanent and contractual employees of the City Municipal Corporation (CMC).
+
+1.2 This policy does not apply to daily wage workers or consultants. Those categories are governed by their respective contracts.
+   [QUOTED VERBATIM - summarisation risked meaning loss]
+
+2.1 Each permanent employee is entitled to 18 days of paid annual leave per calendar year.
+
+2.2 Annual leave accrues at 1.5 days per month from the date of joining.
+   [QUOTED VERBATIM - summarisation risked meaning loss]
+
+2.3 Employees must submit a leave application at least 14 calendar days in advance using Form HR-L1.
+
+2.4 Leave applications must receive written approval from the employee's direct manager before the leave commences. Verbal approval is not valid.
+
+2.5 Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.
+
+2.6 Employees may carry forward a maximum of 5 unused annual leave days to the following calendar year. Any days above 5 are forfeited on 31 December.
+
+2.7 Carry-forward days must be used within the first quarter (January–March) of the following year or they are forfeited.
+
+3.1 Each employee is entitled to 12 days of paid sick leave per calendar year.
+
+3.2 Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.
+
+3.3 Sick leave cannot be carried forward to the following year.
+
+3.4 Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration.
+
+4.1 Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
+
+4.2 For a third or subsequent child, maternity leave is 12 weeks paid.
+
+4.3 Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+
+4.4 Paternity leave cannot be split across multiple periods.
+
+5.1 An employee may apply for Leave Without Pay only after exhausting all applicable paid leave entitlements.
+
+5.2 LWP requires approval from the Department Head and the HR Director. Manager approval alone is not sufficient.
+
+5.3 LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.
+
+5.4 Periods of LWP do not count toward service for the purposes of seniority, increments, or retirement benefits.
+
+6.1 Employees are entitled to all gazetted public holidays as declared by the State Government each year.
+
+6.2 If an employee is required to work on a public holiday, they are entitled to one compensatory off day, to be taken within 60 days of the holiday worked.
+
+6.3 Compensatory off cannot be encashed.
+
+7.1 Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.
+
+7.2 Leave encashment during service is not permitted under any circumstances.
+
+7.3 Sick leave and LWP cannot be encashed under any circumstances.
+
+8.1 Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+
+8.2 Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.


### PR DESCRIPTION
# Vibe Coding Workshop — Submission PR

**Name:** PSergio984
**City / Group:** Pune
**Date:** 2026-08-22
**AI tool(s) used:** opencode (ox-alpha)

---

## Checklist — Complete Before Opening This PR

- [x] `agents.md` committed for UC-0A and UC-0B *(UC-0C/X in progress on this same branch)*
- [x] `skills.md` committed for UC-0A and UC-0B *(UC-0C/X in progress on this same branch)*
- [x] `classifier.py` runs on `test_pune.csv` without crash
- [x] `results_pune.csv` present in `uc-0a/`
- [ ] `app.py` for UC-0B, UC-0C, UC-X — *to be added on this branch per session plan*
- [ ] `summary_hr_leave.txt` present in `uc-0b/` — *pending*
- [ ] `growth_output.csv` present in `uc-0c/` — *pending*
- [ ] 4+ commits with meaningful messages following the formula — *4 of 4+ so far (2 per UC so far); one branch for the entire session per repo instructions*
- [x] All sections below are filled in

---

## UC-0A — Complaint Classifier

**Which failure mode did you encounter first?**
*(taxonomy drift / severity blindness / missing justification / hallucinated sub-categories / false confidence)*

> Severity blindness — a naive keyword-free pass leaves injury/child/school complaints (PM-202402, PM-202420, PM-202446) unflagged as Urgent. False confidence was handled next via the NEEDS_REVIEW flag for genuinely ambiguous rows.

**What enforcement rule fixed it? Quote the rule exactly as it appears in your agents.md:**

> "Priority must be Urgent if description contains any of: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse"

**How many rows in your results CSV match the answer key?**
*(Tutor will release answer key after session)*

> Answer key pending — internal audit: 15 out of 15 rows conform to the schema (exact taxonomy strings, severity-keyword rule, reason citation, ambiguity flags).

**Did all severity signal rows (injury/child/school/hospital) return Urgent?**

> Yes — PM-202402 ("School children"), PM-202411 ("hazard"), PM-202420 ("serious injury"), PM-202446 ("fell"). Word-boundary matching is enforced so lookalikes like "fellow"/"firewood" cannot trigger false Urgents.

**Your git commit message for UC-0A:**

> `[UC-0A] [PSergio984] rule-based complaint classifier with agents.md and skills.md`
> `[UC-0A] Fix precision: substring matches caused false Urgent and wrong categories -> added word-boundary rules`

---

## UC-0B — Summary That Changes Meaning

**Which failure mode did you encounter?**
*(clause omission / scope bleed / obligation softening)*

> Clause omission via pseudo-compression — my first keep-pattern matched nearly every English sentence (`or`, `and`, `if`), so nothing was ever actually summarised and filler sentences silently rode along, risking dropped conditions on any other input document.

**List any clauses that were missing or weakened in the naive output (before your RICE fix):**

> Fixed pre-release by audit: clause 5.2 initially risked keeping "requires approval" while dropping one of the two approvers (the documented trap); box-drawing section dividers were also being glued onto the last clause of each section, corrupting 7 clauses. Both caught by hand-audit + tests before commit.

**After your fix — are all 10 critical clauses present in summary_hr_leave.txt?**

> Yes — all 29 source clauses present; the 10 critical ones (2.3–2.7, 3.2, 3.4, 5.2, 5.3, 7.2) verified condition-complete: 14 days + Form HR-L1; written approval + verbal invalid; LOP regardless of subsequent approval; max 5 carry-forward + 31 December forfeit; Jan–Mar use-or-forfeit; 3+ consecutive days cert within 48 hrs; holiday-adjacency cert regardless of duration; BOTH Department Head AND HR Director ("Manager approval alone is not sufficient"); Municipal Commissioner above 30 continuous days; encashment during service not permitted under any circumstances.

**Did the naive prompt add any information not in the source document (scope bleed)?**

> No — enforced structurally: a test asserts every alphabetic word in every clause line exists in the source document; scope-bleed phrases ("as is standard practice", "typically", "generally expected") are asserted absent.

**Your git commit message for UC-0B:**

> `[UC-0B] [PSergio984] extractive policy summarizer preserving all numbered clauses`
> `[UC-0B] Fix pseudo-compression: keep-pattern matched nearly every sentence -> real extraction that flags only obligation-loss clauses`

---

## UC-0C — Number That Looks Right

*Not yet started — will be completed on this same branch.*

---

## UC-X — Ask My Documents

*Not yet started — will be completed on this same branch.*

---

## CRAFT Loop Reflection

**Which CRAFT step was hardest across all UCs, and why?**

> Refine — deciding what counts as "genuinely ambiguous" required hand-auditing every row and choosing explicit precedence rules (e.g., Heritage Damage beats Streetlight but must set NEEDS_REVIEW) rather than letting implicit ordering decide silently.

**What is the single most important thing you added manually to an agents.md that the AI did not generate on its own?**

> The refusal condition with word boundaries made explicit: "Refusal condition: If no category cue can be determined from the description alone, output category: Other and flag: NEEDS_REVIEW" — plus restricting context to only complaint_id and description fields.

**Name one real task in your work where you will apply RICE + CRAFT within the next two weeks:**

> Building an intake-triage rule set for support tickets: intent + context defined up front, testable enforcement rules (exact queue names, escalation triggers), refusal path to a human-review queue.

---

## Reviewer Notes *(tutor fills this section)*

| Criterion | Score /4 | Notes |
|---|---|---|
| RICE prompt quality | | |
| agents.md quality | | |
| skills.md quality | | |
| CRAFT loop evidence | | |
| Test coverage | | |
| **Total** | **/20** | |

**Badge decision:**
- [ ] Standard badge — meets pass threshold (score 11+/20 on this review, full rubric 22+/40)
- [ ] Distinction badge — meets distinction threshold (score 17+/20 on this review, full rubric 34+/40)
- [ ] Not yet — resubmit after addressing: _______________

