### PR TITLE
[Kerala] Sarath — Vibe Coding Submission

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,34 @@
 # agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Municipal complaint classifier. Given one citizen complaint record, it decides
+  what kind of problem is being reported, how urgent it is, and why. Its
+  operational boundary ends at producing classification fields — it does not
+  route work, schedule crews, contact reporters, or modify the complaint record.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  Every complaint row receives four verdicts that are mechanically verifiable:
+  1. category is exactly one of the ten allowed strings (see enforcement rule 1) —
+     never a variant, synonym, or sub-type;
+  2. priority is Urgent whenever the description contains any severity keyword;
+     otherwise Standard, or Low only for clearly non-disruptive issues;
+  3. reason is one sentence quoting specific words from the description that
+     justify the category (and the priority, when Urgent);
+  4. flag is NEEDS_REVIEW exactly when the description does not clearly support
+     a single category — ambiguity is surfaced, never guessed away.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the fields present in the input row, with the
+  description text as the primary evidence. Ward, location, date_raised and
+  days_open may be read for context but must never be used to invent a category
+  or override the severity-keyword rule. Explicit exclusions: no outside
+  knowledge about the city or its infrastructure; no assumptions about reporter
+  reliability (reported_by is not evidence); no escalation based on how long a
+  complaint has been open; no details that are not stated in the description.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "Category must be exactly one of: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other. Any other string (e.g. 'Potholes', 'Road Damage (Major)', 'Garbage') is invalid."
+  - "Priority must be Urgent if the description contains any of these keywords (case-insensitive): injury, child, school, hospital, ambulance, fire, hazard, fell, collapse. The keyword rule overrides every other signal."
+  - "Every output row must include a reason field: one sentence citing at least one word or phrase taken directly from the description."
+  - "Complaints with materially equivalent descriptions must receive the same category in every row — no taxonomy drift across a batch."
+  - "Refusal condition: if the category cannot be determined from the description alone (conflicting or insufficient evidence), output category: Other with flag: NEEDS_REVIEW; priority still follows the severity-keyword rule."

--- a/uc-0a/classifier.py
+++ b/uc-0a/classifier.py
@@ -1,29 +1,167 @@
 """
 UC-0A — Complaint Classifier
-Starter file. Build this using the RICE → agents.md → skills.md → CRAFT workflow.
+Deterministic, rules-based classification of citizen complaints into the fixed
+UC-0A taxonomy. Implements the contracts defined in agents.md and skills.md:
+exact category strings, keyword-driven Urgent priority, quoted justification,
+and NEEDS_REVIEW surfacing of genuine ambiguity.
 """
 import argparse
 import csv
+import re
+import sys
+
+CATEGORIES = (
+    "Pothole", "Flooding", "Streetlight", "Waste", "Noise",
+    "Road Damage", "Heritage Damage", "Heat Hazard", "Drain Blockage", "Other",
+)
+
+OUTPUT_COLUMNS = ("complaint_id", "category", "priority", "reason", "flag")
+
+SEVERITY_PATTERNS = (
+    ("injury",    re.compile(r"\binjur\w*", re.I)),
+    ("child",     re.compile(r"\bchild\w*", re.I)),
+    ("school",    re.compile(r"\bschool\w*", re.I)),
+    ("hospital",  re.compile(r"\bhospital\w*", re.I)),
+    ("ambulance", re.compile(r"\bambulances?\b", re.I)),
+    ("fire",      re.compile(r"\bfires?\b", re.I)),
+    ("hazard",    re.compile(r"\bhazard\w*", re.I)),
+    ("fell",      re.compile(r"\bfell\b|\bfalls?\b|\bfalling\b|\bfallen\b", re.I)),
+    ("collapse",  re.compile(r"\bcollaps\w*", re.I)),
+)
+
+
+def _rules(*patterns):
+    return [re.compile(p, re.I) for p in patterns]
+
+
+CATEGORY_RULES = {
+    "Pothole": _rules(
+        r"\bpotholes?\b", r"\bpot\s?holes?\b",
+    ),
+    "Flooding": _rules(
+        r"\bflood\w*", r"water\s?log\w*", r"\bsubmerg\w*|\binundat\w*",
+        r"\bstanding water\b",
+    ),
+    "Streetlight": _rules(
+        r"\bstreet\s?lights?\b", r"\blamp\s?posts?\b", r"\blights?\s+out\b",
+        r"\bunlit\b", r"\bdark(?:ness)?\b",
+    ),
+    "Waste": _rules(
+        r"\bwastes?\b", r"\bgarbage\b", r"\btrash\b", r"\blitter\w*",
+        r"\bdump\w*", r"\bdead animals?\b", r"\bbins?\b",
+    ),
+    "Noise": _rules(
+        r"\bmusic\b", r"\bnois[ey]\w*", r"\bamplifier\w*", r"\bloudspeakers?\b",
+        r"\bdrill\w*", r"\bbands?\b",
+    ),
+    "Road Damage": _rules(
+        r"\bsub\s?sid\w*", r"\bbuckl\w*", r"\bcrack\w*", r"\bsink\w*|\bsunken\b",
+        r"\bcraters?\b", r"\bcollaps\w*", r"\bfootpaths?\b", r"\bpav\w*",
+        r"\btiles?\b", r"\bcobblestones?\b", r"\bupturn\w*", r"\broad surface\b",
+    ),
+    "Heritage Damage": _rules(
+        r"\bheritage\b", r"\bhistoric\w*", r"\bancient\b", r"\bmonuments?\b",
+        r"\bdefac\w*", r"\bstep wells?\b",
+    ),
+    "Heat Hazard": _rules(
+        r"\bheat\w*", r"°\s?C", r"\btemperatures?\b", r"\bmelt\w*",
+        r"\bbubbl\w*", r"\bunbearabl\w*", r"exposed to (the )?(full )?sun",
+        r"\bscorch\w*",
+    ),
+    "Drain Blockage": _rules(
+        r"\bblock(?:ed|age|ing)?\b", r"\bclogg?\w*",
+        r"\bstormwater drains?\b", r"\bmain drains?\b",
+    ),
+}
+
 
 def classify_complaint(row: dict) -> dict:
     """
     Classify a single complaint row.
     Returns: dict with keys: complaint_id, category, priority, reason, flag
-    
-    TODO: Build this using your AI tool guided by your agents.md and skills.md.
-    Your RICE enforcement rules must be reflected in this function's behaviour.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    complaint_id = (row.get("complaint_id") or "").strip()
+    description = (row.get("description") or "").strip()
+
+    severity_hits = [
+        mo.group(0) for _, rx in SEVERITY_PATTERNS if (mo := rx.search(description))
+    ]
+    priority = "Urgent" if severity_hits else "Standard"
+
+    if not description:
+        return {
+            "complaint_id": complaint_id,
+            "category": "Other",
+            "priority": priority,
+            "reason": "No description text available to justify any category.",
+            "flag": "NEEDS_REVIEW",
+        }
+
+    scored = []
+    for category in CATEGORIES:
+        if category == "Other":
+            continue
+        hits = list(dict.fromkeys(
+            m.group(0)
+            for rx in CATEGORY_RULES[category]
+            if (m := rx.search(description))
+        ))
+        scored.append((len(hits), CATEGORIES.index(category), category, hits))
+    scored.sort(key=lambda t: (-t[0], t[1]))
+
+    best_score, _, best_category, best_hits = scored[0]
+    runner_up_score = scored[1][0]
+
+    if best_score == 0:
+        excerpt = description if len(description) <= 60 else description[:57] + "..."
+        return {
+            "complaint_id": complaint_id,
+            "category": "Other",
+            "priority": priority,
+            "reason": f"No schema category matches the described problem ('{excerpt}').",
+            "flag": "NEEDS_REVIEW",
+        }
+
+    cited = ", ".join(f"'{h}'" for h in best_hits[:2])
+    reason = f"{best_category}: description cites {cited}"
+    if severity_hits:
+        reason += f"; urgent due to '{severity_hits[0]}'"
+
+    return {
+        "complaint_id": complaint_id,
+        "category": best_category,
+        "priority": priority,
+        "reason": reason + ".",
+        "flag": "NEEDS_REVIEW" if runner_up_score == best_score else "",
+    }
 
 
 def batch_classify(input_path: str, output_path: str):
     """
     Read input CSV, classify each row, write results CSV.
-    
-    TODO: Build this using your AI tool.
-    Must: flag nulls, not crash on bad rows, produce output even if some rows fail.
+    Flags nulls, never crashes on bad rows, always produces output.
     """
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    try:
+        input_file = open(input_path, newline="", encoding="utf-8")
+    except OSError as exc:
+        sys.exit(f"error: cannot read input file '{input_path}': {exc}")
+
+    with input_file, open(output_path, "w", newline="", encoding="utf-8") as out_file:
+        reader = csv.DictReader(input_file)
+        writer = csv.writer(out_file)
+        writer.writerow(OUTPUT_COLUMNS)
+        for row in reader:
+            try:
+                result = classify_complaint(row)
+            except Exception as exc:
+                result = {
+                    "complaint_id": (row.get("complaint_id") or "").strip(),
+                    "category": "Other",
+                    "priority": "Standard",
+                    "reason": f"Row could not be processed ({exc}).",
+                    "flag": "NEEDS_REVIEW",
+                }
+            writer.writerow([result[col] for col in OUTPUT_COLUMNS])
 
 
 if __name__ == "__main__":

--- a/uc-0a/results_ahmedabad.csv
+++ b/uc-0a/results_ahmedabad.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+AM-202401,Heat Hazard,Standard,"Heat Hazard: description cites '°C', 'melting'.",
+AM-202402,Heat Hazard,Standard,Heat Hazard: description cites 'temperatures'.,
+AM-202405,Other,Urgent,No schema category matches the described problem ('Dead trees with split branches. Fall risk to walkers. 3 t...').,NEEDS_REVIEW
+AM-202406,Heat Hazard,Standard,Heat Hazard: description cites 'heatwave'.,
+AM-202407,Road Damage,Urgent,"Road Damage: description cites 'paving', 'upturned'; urgent due to 'injured'.",
+AM-202410,Pothole,Standard,Pothole: description cites 'Pothole'.,
+AM-202414,Streetlight,Standard,Streetlight: description cites 'unlit'.,
+AM-202417,Waste,Standard,Waste: description cites 'waste'.,NEEDS_REVIEW
+AM-202421,Noise,Standard,Noise: description cites 'music'.,
+AM-202424,Heat Hazard,Standard,"Heat Hazard: description cites '°C', 'bubbling'.",
+AM-202429,Heat Hazard,Standard,"Heat Hazard: description cites '°C', 'temperature'.",
+AM-202431,Heritage Damage,Standard,"Heritage Damage: description cites 'Heritage', 'ancient'.",
+AM-202435,Heat Hazard,Standard,Heat Hazard: description cites 'heat'.,
+AM-202444,Waste,Standard,"Waste: description cites 'waste', 'bins'.",
+AM-202445,Heat Hazard,Standard,Heat Hazard: description cites 'exposed to full sun'.,

--- a/uc-0a/results_hyderabad.csv
+++ b/uc-0a/results_hyderabad.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+GH-202401,Flooding,Urgent,Flooding: description cites 'flooded'; urgent due to 'Ambulance'.,
+GH-202402,Flooding,Standard,Flooding: description cites 'flooded'.,NEEDS_REVIEW
+GH-202406,Drain Blockage,Standard,"Drain Blockage: description cites 'blocked', 'stormwater drain'.",
+GH-202407,Drain Blockage,Standard,Drain Blockage: description cites 'blocked'.,
+GH-202410,Pothole,Standard,Pothole: description cites 'Potholes'.,
+GH-202411,Pothole,Urgent,Pothole: description cites 'Pothole'; urgent due to 'hospitalised'.,
+GH-202412,Pothole,Urgent,Pothole: description cites 'potholes'; urgent due to 'School'.,
+GH-202417,Waste,Standard,"Waste: description cites 'waste', 'garbage'.",
+GH-202420,Noise,Standard,Noise: description cites 'drilling'.,
+GH-202422,Road Damage,Urgent,"Road Damage: description cites 'Crater', 'collapsed'; urgent due to 'collapsed'.",
+GH-202424,Flooding,Standard,Flooding: description cites 'floods'.,
+GH-202428,Waste,Standard,Waste: description cites 'waste'.,
+GH-202432,Other,Standard,No schema category matches the described problem ('24hr supermarket delivery trucks idling with engines on.').,NEEDS_REVIEW
+GH-202448,Drain Blockage,Standard,"Drain Blockage: description cites 'blocked', 'Main drain'.",
+GH-202438,Other,Standard,No schema category matches the described problem ('Colony surrounded by fields that channel rainwater throug...').,NEEDS_REVIEW

--- a/uc-0a/results_kolkata.csv
+++ b/uc-0a/results_kolkata.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+KM-202401,Streetlight,Standard,Streetlight: description cites 'lamp post'.,NEEDS_REVIEW
+KM-202402,Road Damage,Standard,Road Damage: description cites 'cobblestones'.,NEEDS_REVIEW
+KM-202405,Noise,Standard,Noise: description cites 'band'.,
+KM-202409,Pothole,Standard,Pothole: description cites 'potholes'.,
+KM-202410,Pothole,Standard,Pothole: description cites 'Pothole'.,
+KM-202411,Pothole,Standard,Pothole: description cites 'pothole'.,
+KM-202415,Other,Standard,No schema category matches the described problem ('New residential complex draining directly onto public road.').,NEEDS_REVIEW
+KM-202418,Waste,Standard,Waste: description cites 'waste'.,
+KM-202421,Road Damage,Urgent,"Road Damage: description cites 'sinking', 'Footpath'; urgent due to 'Hospital'.",
+KM-202422,Road Damage,Standard,"Road Damage: description cites 'buckled', 'Road surface'.",
+KM-202426,Heritage Damage,Standard,"Heritage Damage: description cites 'Heritage', 'defaced'.",
+KM-202430,Road Damage,Standard,Road Damage: description cites 'subsided'.,
+KM-202434,Road Damage,Standard,Road Damage: description cites 'paving'.,NEEDS_REVIEW
+KM-202436,Streetlight,Standard,Streetlight: description cites 'Darkness'.,
+KM-202438,Noise,Standard,Noise: description cites 'amplifiers'.,NEEDS_REVIEW

--- a/uc-0a/results_pune.csv
+++ b/uc-0a/results_pune.csv
@@ -1,0 +1,16 @@
+complaint_id,category,priority,reason,flag
+PM-202401,Pothole,Standard,Pothole: description cites 'pothole'.,
+PM-202402,Pothole,Urgent,Pothole: description cites 'pothole'; urgent due to 'children'.,
+PM-202406,Flooding,Standard,Flooding: description cites 'flooded'.,
+PM-202408,Flooding,Standard,Flooding: description cites 'flooded'.,NEEDS_REVIEW
+PM-202410,Streetlight,Standard,"Streetlight: description cites 'streetlights', 'dark'.",
+PM-202411,Streetlight,Urgent,Streetlight: description cites 'Streetlight'; urgent due to 'hazard'.,
+PM-202413,Waste,Standard,"Waste: description cites 'garbage', 'bins'.",
+PM-202418,Noise,Standard,Noise: description cites 'music'.,
+PM-202419,Road Damage,Standard,"Road Damage: description cites 'cracked', 'sinking'.",
+PM-202420,Other,Urgent,No schema category matches the described problem ('Manhole cover missing. Risk of serious injury to cyclists.').,NEEDS_REVIEW
+PM-202427,Flooding,Standard,Flooding: description cites 'floods'.,
+PM-202428,Waste,Standard,Waste: description cites 'Dead animal'.,
+PM-202430,Streetlight,Standard,"Streetlight: description cites 'lights out', 'dark'.",
+PM-202433,Waste,Standard,"Waste: description cites 'waste', 'dumped'.",
+PM-202446,Road Damage,Urgent,"Road Damage: description cites 'Footpath', 'tiles'; urgent due to 'fell'.",

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0A Complaint Classifier
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: Assigns a category, priority, one-sentence justification and optional NEEDS_REVIEW flag to a single complaint row.
+    input: One complaint row as a dict; required key is description (string), plus complaint_id for traceability.
+    output: A dict with keys complaint_id, category, priority, reason, flag — where category is one of the ten exact schema strings, priority is one of Urgent/Standard/Low, reason is a single sentence quoting the description, and flag is NEEDS_REVIEW or empty.
+    error_handling: Missing or empty description yields category Other with flag NEEDS_REVIEW instead of failing; ambiguous evidence yields NEEDS_REVIEW with the best-supported category rather than a confident guess; never raises on unexpected field values.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: Reads a city test CSV, applies classify_complaint to every row, and writes the classified results to an output CSV.
+    input: Path to an input CSV (header row, UTF-8) containing at least complaint_id and description columns, and the path to write the results CSV.
+    output: A results CSV with columns complaint_id, category, priority, reason, flag — exactly one output row per input row in the same order.
+    error_handling: A malformed row is emitted as category Other with flag NEEDS_REVIEW instead of aborting the batch; a missing or unreadable input file exits with a clear error before any output is written.

--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,40 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0B Policy Summariser
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Faithful policy-document summariser. Given the City Municipal Corporation
+  Employee Leave Policy as numbered clauses, it produces a condensed summary in
+  which every clause keeps its original legal effect. Its operational boundary
+  ends at producing the summary text — it does not interpret, advise on, or
+  apply the policy, and it never decides what a "reasonable" rule would be.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is mechanically verifiable against the source document:
+  1. every numbered clause of the source appears in the summary under its own
+     clause number — omission is failure;
+  2. every condition attached to an obligation survives summarisation — a rule
+     with two approvers still names both approvers, a deadline still carries
+     its exact time limit, an exception is never dropped;
+  3. binding force is preserved verbatim-class: "must" stays must, "requires"
+     stays requires, "not permitted" stays prohibited, "will be recorded"
+     stays definite — softening "must" into "should" or "is expected to" is
+     failure;
+  4. nothing appears in the summary that is absent from the source — no
+     standard practice claims, no typical-organisation framing, no added
+     rationale;
+  5. each summary sentence is traceable to the clause number it cites.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the text of the supplied policy document. Explicit
+  exclusions: no outside knowledge of Indian labour law, municipal practice,
+  or other employers' policies; no generalisations such as "as is standard
+  practice" or "employees are generally expected to" — none of these are in
+  the source; no invented numbers, deadlines, thresholds, or approver roles;
+  no merging of clauses that silently drops one of them.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause in the source (1.1 through 8.2) must appear in the summary, referenced by its clause number."
+  - "Multi-condition obligations must preserve ALL conditions — e.g. clause 5.2 names both approvers (Department Head AND HR Director); dropping either one invalidates the output."
+  - "Quantitative terms and their anchors must survive unchanged: 14 calendar days notice via Form HR-L1 (2.3), max 5 carry-forward days with the excess forfeited on 31 December (2.6), Jan–Mar usage window (2.7), medical certificate within 48 hours of RETURNING TO WORK for 3+ consecutive sick days (3.2), LWP exceeding 30 continuous days (5.3)."
+  - "Binding verbs are preserved: 'must' (2.3, 2.4, 2.7), 'may carry forward ... are forfeited' (2.6), 'requires' (3.2, 3.4, 5.2, 5.3), 'will' (2.5), 'not permitted / cannot ... under any circumstances' (7.2) — never replaced by weaker phrasing such as 'should', 'is encouraged to', or 'typically'."
+  - "No sentence may introduce information absent from the source document; scope-bleed phrases ('standard practice', 'typically in government organisations') are forbidden."
+  - "Refusal condition: if any clause cannot be condensed without risk of meaning loss, quote that clause verbatim inside the summary and mark it with [FLAGGED: quoted verbatim] instead of guessing at a paraphrase."

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -223,7 +223,8 @@ def retrieve_policy(path):
 
 
 def _verbatim(num, text):
-    return f"{num} {re.sub(r'\s+', ' ', text).strip()} {FLAG_MARK}"
+    flat = re.sub(r"\s+", " ", text).strip()
+    return f"{num} {flat} {FLAG_MARK}"
 
 
 def summarize_policy(sections):

--- a/uc-0b/app.py
+++ b/uc-0b/app.py
@@ -1,12 +1,318 @@
-"""
-UC-0B app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+"""UC-0B policy summariser — deterministic, meaning-preserving.
+
+Implements agents.md (faithful summarisation contract) and skills.md
+(retrieve_policy + summarize_policy). Condenses only clauses whose
+verified condensed form passes guard checks against the parsed source;
+every other clause is quoted verbatim and flagged per the refusal rule.
 """
 import argparse
+import re
+import sys
+
+SEP_RE = re.compile(r"^\s*═+\s*$")
+CLAUSE_RE = re.compile(r"^(\d+\.\d+)\s+(.*)$")
+DOCREF_RE = re.compile(r"^Document Reference:\s*(.+)$", re.M)
+VERSION_RE = re.compile(r"^Version:\s*(.+)$", re.M)
+
+SCOPE_BLEED_PHRASES = [
+    "standard practice",
+    "typically",
+    "generally expected",
+]
+
+STRONG_VERB_PATTERNS = [
+    r"\bmust\b",
+    r"\brequires?\b",
+    r"\bwill\b",
+    r"\bcannot\b",
+    r"\bshall\b",
+    r"\bmays?\b",
+    r"\bentitled\b",
+    r"not permitted",
+    r"not valid",
+    r"not sufficient",
+    r"are forfeited",
+    r"is forfeited",
+]
+
+CONDENSED = {
+    "1.1": {
+        "text": "Governs all leave entitlements for permanent and contractual CMC employees.",
+        "guards": ["leave entitlements", "permanent", "contractual", "CMC"],
+    },
+    "1.2": {
+        "text": "Does not apply to daily wage workers or consultants; those categories are governed by their respective contracts.",
+        "guards": ["does not apply", "daily wage workers", "consultants", "respective contracts"],
+    },
+    "2.1": {
+        "text": "Permanent employees are entitled to 18 days of paid annual leave per calendar year.",
+        "guards": ["18", "paid annual leave", "calendar year", "entitled"],
+    },
+    "2.2": {
+        "text": "Annual leave accrues at 1.5 days per month from the date of joining.",
+        "guards": ["1.5", "per month", "date of joining"],
+    },
+    "2.3": {
+        "text": "Leave application must be submitted at least 14 calendar days in advance, using Form HR-L1.",
+        "guards": ["must", "14", "calendar days", "Form HR-L1"],
+    },
+    "2.4": {
+        "text": "Leave applications must receive written approval from the employee's direct manager before the leave commences; verbal approval is not valid.",
+        "guards": ["must", "written approval", "direct manager", "before the leave commences", "verbal approval", "not valid"],
+    },
+    "2.5": {
+        "text": "Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.",
+        "guards": ["will be recorded", "Loss of Pay", "LOP", "regardless of subsequent approval"],
+    },
+    "2.6": {
+        "text": "A maximum of 5 unused annual leave days may be carried forward to the following calendar year; any days above 5 are forfeited on 31 December.",
+        "guards": ["5", "may", ["carry forward", "carried forward"], "following calendar year", "above 5", "are forfeited", "31 December"],
+    },
+    "2.7": {
+        "text": "Carry-forward days must be used within the first quarter (January-March) of the following year or they are forfeited.",
+        "guards": ["must", "first quarter", "January-March", "following year", "forfeited"],
+    },
+    "3.1": {
+        "text": "Each employee is entitled to 12 days of paid sick leave per calendar year.",
+        "guards": ["12", "paid sick leave", "calendar year", "entitled"],
+    },
+    "3.2": {
+        "text": "Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.",
+        "guards": ["3", "consecutive days", "requires", "medical certificate", "registered medical practitioner", "48 hours", "returning to work"],
+    },
+    "3.3": {
+        "text": "Sick leave cannot be carried forward to the following year.",
+        "guards": ["cannot", "carried forward", "following year"],
+    },
+    "3.4": {
+        "text": "Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration.",
+        "guards": ["immediately before or after", "public holiday", "annual leave period", "requires", "medical certificate", "regardless of duration"],
+    },
+    "4.1": {
+        "text": "Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.",
+        "guards": ["female employees", "entitled", "26 weeks", "paid maternity leave", "first two live births"],
+    },
+    "4.2": {
+        "text": "For a third or subsequent child, maternity leave is 12 weeks paid.",
+        "guards": ["third or subsequent child", "12 weeks", "paid"],
+    },
+    "4.3": {
+        "text": "Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.",
+        "guards": ["male employees", "entitled", "5 days", "paid paternity leave", "30 days", "child's birth"],
+    },
+    "4.4": {
+        "text": "Paternity leave cannot be split across multiple periods.",
+        "guards": ["cannot", "split", "multiple periods"],
+    },
+    "5.1": {
+        "text": "LWP may be applied for only after exhausting all applicable paid leave entitlements.",
+        "guards": ["may", "only after", "exhausting", "paid leave entitlements"],
+    },
+    "5.2": {
+        "text": "LWP requires approval from both the Department Head and the HR Director; manager approval alone is not sufficient.",
+        "guards": ["requires", "department head", "hr director", "manager approval alone", "not sufficient"],
+    },
+    "5.3": {
+        "text": "LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.",
+        "guards": ["exceeding", "30 continuous days", "requires", "Municipal Commissioner"],
+    },
+    "5.4": {
+        "text": "Periods of LWP do not count toward service for seniority, increments, or retirement benefits.",
+        "guards": ["do not count toward service", "seniority", "increments", "retirement benefits"],
+    },
+    "6.1": {
+        "text": "Employees are entitled to all gazetted public holidays as declared by the State Government each year.",
+        "guards": ["entitled", "gazetted public holidays", "State Government", "each year"],
+    },
+    "6.2": {
+        "text": "An employee required to work on a public holiday is entitled to one compensatory off day, to be taken within 60 days of the holiday worked.",
+        "guards": ["required to work", "public holiday", "one compensatory off day", "60 days", "holiday worked"],
+    },
+    "6.3": {
+        "text": "Compensatory off cannot be encashed.",
+        "guards": ["cannot", "encashed"],
+    },
+    "7.1": {
+        "text": "Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.",
+        "guards": ["may be encashed", "only", "retirement", "resignation", "maximum of 60 days"],
+    },
+    "7.2": {
+        "text": "Leave encashment during service is not permitted under any circumstances.",
+        "guards": ["not permitted", "under any circumstances", "during service"],
+    },
+    "7.3": {
+        "text": "Sick leave and LWP cannot be encashed under any circumstances.",
+        "guards": ["cannot", "encashed", "under any circumstances"],
+    },
+    "8.1": {
+        "text": "Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.",
+        "guards": ["must", "HR Department", "10 working days", "disputed decision"],
+    },
+    "8.2": {
+        "text": "Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.",
+        "guards": ["after 10 working days", "will not be considered", "exceptional circumstances", "in writing"],
+    },
+}
+
+FLAG_MARK = "[FLAGGED: quoted verbatim]"
+
+
+def _norm(text):
+    text = text.replace("\u2013", "-").replace("\u2014", "-").replace("\u2019", "'")
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def _guard_present(guard, norm_text):
+    guard_n = _norm(guard)
+    if re.fullmatch(r"[\w\s/-]+", guard_n):
+        pattern = r"(?<![a-z0-9])" + re.escape(guard_n).replace(r"\ ", r"\s+") + r"(?![a-z0-9])"
+        return re.search(pattern, norm_text) is not None
+    return guard_n in norm_text
+
+
+def _concept_present(concept, norm_src, norm_cond):
+    variants = concept if isinstance(concept, list) else [concept]
+    return any(_guard_present(v, norm_src) for v in variants) and any(
+        _guard_present(v, norm_cond) for v in variants
+    )
+
+
+def retrieve_policy(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+    except OSError as exc:
+        sys.exit(f"error: cannot read input file '{path}': {exc}")
+
+    sections = []
+    pending_title = None
+    current = None
+    open_clause = None
+
+    for raw in lines:
+        line = raw.rstrip()
+        if SEP_RE.match(line):
+            continue
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = CLAUSE_RE.match(stripped)
+        if match:
+            num, first = match.group(1), match.group(2).strip()
+            if pending_title is not None:
+                current = {"title": pending_title, "clauses": {}}
+                sections.append(current)
+                pending_title = None
+            if current is None:
+                current = {"title": "", "clauses": {}}
+                sections.append(current)
+            current["clauses"][num] = first
+            open_clause = num
+        elif open_clause is not None:
+            current["clauses"][open_clause] = current["clauses"][open_clause] + " " + stripped
+            if pending_title is not None:
+                pending_title = None
+        else:
+            pending_title = stripped
+
+    total = sum(len(sec["clauses"]) for sec in sections)
+    if total == 0:
+        sys.exit(f"error: no numbered clauses recognised in '{path}' - aborting rather than emitting an empty summary")
+
+    return sections
+
+
+def _verbatim(num, text):
+    return f"{num} {re.sub(r'\s+', ' ', text).strip()} {FLAG_MARK}"
+
+
+def summarize_policy(sections):
+    out = []
+    condensed_count = 0
+    flagged_count = 0
+    for sec in sections:
+        if sec["title"]:
+            out.append("")
+            out.append(sec["title"])
+        for num, text in sec["clauses"].items():
+            entry = CONDENSED.get(num)
+            norm_src = _norm(text)
+            usable = False
+            if entry:
+                norm_cond = _norm(entry["text"])
+                guards_ok = all(_concept_present(g, norm_src, norm_cond) for g in entry["guards"])
+                src_verbs = [p for p in STRONG_VERB_PATTERNS if re.search(p, norm_src)]
+                verbs_ok = (
+                    not src_verbs
+                    or any(re.search(p, norm_cond) for p in src_verbs)
+                )
+                usable = guards_ok and verbs_ok
+            if usable:
+                out.append(f"{num} {entry['text']}")
+                condensed_count += 1
+            else:
+                out.append(_verbatim(num, text))
+                flagged_count += 1
+    return "\n".join(out).lstrip("\n"), condensed_count, flagged_count
+
+
+def _validate(summary, sections, condensed_count):
+    parsed_nums = {num for sec in sections for num in sec["clauses"]}
+    summary_nums = set(re.findall(r"^(\d+\.\d+)\s", summary, re.M))
+    missing = parsed_nums - summary_nums
+    if missing:
+        sys.exit(f"error: clauses missing from summary: {sorted(missing)} - refusing to write output")
+    extra = summary_nums - parsed_nums
+    if extra:
+        sys.exit(f"error: summary references unknown clauses: {sorted(extra)} - refusing to write output")
+    norm_summary = _norm(summary)
+    for phrase in SCOPE_BLEED_PHRASES:
+        if phrase in norm_summary:
+            sys.exit(f"error: scope-bleed phrase '{phrase}' detected - refusing to write output")
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(
+        description="UC-0B deterministic policy summariser (meaning-preserving)."
+    )
+    parser.add_argument("--input", required=True, help="path to the plain-text policy document")
+    parser.add_argument("--output", required=True, help="path to write the summary")
+    args = parser.parse_args()
+
+    sections = retrieve_policy(args.input)
+    body, condensed_count, flagged_count = summarize_policy(sections)
+    _validate(body, sections, condensed_count)
+
+    total = sum(len(sec["clauses"]) for sec in sections)
+    header_lines = []
+    try:
+        with open(args.input, encoding="utf-8") as fh:
+            head = fh.read(2048)
+        ref = DOCREF_RE.search(head)
+        ver = VERSION_RE.search(head)
+        if ref:
+            header_lines.append(f"Source: {ref.group(1).strip()}")
+        if ver:
+            header_lines.append(f"Version: {ver.group(1).strip()}")
+    except OSError:
+        pass
+
+    parts = ["UC-0B Policy Summary"]
+    parts.extend(header_lines)
+    parts.append(
+        f"Clauses: {total} total, {condensed_count} condensed, {flagged_count} "
+        f"{FLAG_MARK}. Every clause retains its original obligations."
+    )
+    document = "\n".join(parts) + "\n\n" + body + "\n"
+
+    try:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(document)
+    except OSError as exc:
+        sys.exit(f"error: cannot write output file '{args.output}': {exc}")
+
+    print(f"Wrote {args.output}: {total} clauses ({condensed_count} condensed, {flagged_count} flagged verbatim)")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0B Policy Summariser
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Loads a plain-text policy document and returns its content parsed into structured numbered sections.
+    input: Path to a UTF-8 plain-text (.txt) policy file whose clauses follow the pattern "N.M <text>" grouped under section headers.
+    output: An ordered list of sections; each section has its heading plus a list of clauses keyed by their full clause number ("2.3") with the complete clause text, including continuation lines.
+    error_handling: A missing or unreadable file exits with a clear error before anything is processed; a file yielding zero recognised clauses aborts with a parse error rather than returning empty structure; clause numbers are kept as literal strings so "2.10" is never confused with "2.1".
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Produces a meaning-preserving summary of structured policy sections in which every clause survives with identical obligations and binding force.
+    input: The ordered list of sections returned by retrieve_policy.
+    output: Plain-text summary in which every clause appears under its own clause number with all conditions intact and binding verbs preserved; clauses that cannot be safely condensed are quoted verbatim and marked [FLAGGED: quoted verbatim].
+    error_handling: A clause whose condensation would drop any condition, quantity, approver, or binding verb is quoted verbatim and flagged instead of paraphrased; an input missing expected clause numbering aborts with an error rather than producing a partial summary; never invents content to fill gaps in the input.

--- a/uc-0b/summary_hr_leave.txt
+++ b/uc-0b/summary_hr_leave.txt
@@ -1,0 +1,35 @@
+UC-0B Policy Summary
+Source: HR-POL-001
+Version: 2.3 | Effective: 1 April 2024
+Clauses: 29 total, 29 condensed, 0 [FLAGGED: quoted verbatim]. Every clause retains its original obligations.
+
+1. PURPOSE AND SCOPE
+1.1 Governs all leave entitlements for permanent and contractual CMC employees.
+1.2 Does not apply to daily wage workers or consultants; those categories are governed by their respective contracts.
+2.1 Permanent employees are entitled to 18 days of paid annual leave per calendar year.
+2.2 Annual leave accrues at 1.5 days per month from the date of joining.
+2.3 Leave application must be submitted at least 14 calendar days in advance, using Form HR-L1.
+2.4 Leave applications must receive written approval from the employee's direct manager before the leave commences; verbal approval is not valid.
+2.5 Unapproved absence will be recorded as Loss of Pay (LOP) regardless of subsequent approval.
+2.6 A maximum of 5 unused annual leave days may be carried forward to the following calendar year; any days above 5 are forfeited on 31 December.
+2.7 Carry-forward days must be used within the first quarter (January-March) of the following year or they are forfeited.
+3.1 Each employee is entitled to 12 days of paid sick leave per calendar year.
+3.2 Sick leave of 3 or more consecutive days requires a medical certificate from a registered medical practitioner, submitted within 48 hours of returning to work.
+3.3 Sick leave cannot be carried forward to the following year.
+3.4 Sick leave taken immediately before or after a public holiday or annual leave period requires a medical certificate regardless of duration.
+4.1 Female employees are entitled to 26 weeks of paid maternity leave for the first two live births.
+4.2 For a third or subsequent child, maternity leave is 12 weeks paid.
+4.3 Male employees are entitled to 5 days of paid paternity leave, to be taken within 30 days of the child's birth.
+4.4 Paternity leave cannot be split across multiple periods.
+5.1 LWP may be applied for only after exhausting all applicable paid leave entitlements.
+5.2 LWP requires approval from both the Department Head and the HR Director; manager approval alone is not sufficient.
+5.3 LWP exceeding 30 continuous days requires approval from the Municipal Commissioner.
+5.4 Periods of LWP do not count toward service for seniority, increments, or retirement benefits.
+6.1 Employees are entitled to all gazetted public holidays as declared by the State Government each year.
+6.2 An employee required to work on a public holiday is entitled to one compensatory off day, to be taken within 60 days of the holiday worked.
+6.3 Compensatory off cannot be encashed.
+7.1 Annual leave may be encashed only at the time of retirement or resignation, subject to a maximum of 60 days.
+7.2 Leave encashment during service is not permitted under any circumstances.
+7.3 Sick leave and LWP cannot be encashed under any circumstances.
+8.1 Leave-related grievances must be raised with the HR Department within 10 working days of the disputed decision.
+8.2 Grievances raised after 10 working days will not be considered unless exceptional circumstances are demonstrated in writing.

--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -1,18 +1,37 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0C Budget Growth Analyser
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Budget growth analyser for a single ward-and-category slice of the CMC ward
+  budget ledger. Given one ward, one category, and an explicitly named growth
+  type, it produces a per-period growth table for that slice only. Its
+  operational boundary ends at computing and labelling growth for the requested
+  series — it does not forecast, budget, rank wards, advise on spending, or
+  produce any figure that spans more than the one requested ward and category.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct output is mechanically verifiable against the source ledger:
+  1. the output is a per-period table for exactly one ward and one category —
+     never a single aggregated number;
+  2. every period appears in the table, including periods where growth cannot
+     be computed — those carry an explicit flag and the reason from the notes
+     column, never a silent gap;
+  3. every computed row shows the formula actually used, with the real operand
+     values substituted in, next to the result;
+  4. the growth type is the one requested — the system never picks MoM or YoY
+     on the user's behalf.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the columns of the supplied CSV: period, ward,
+  category, budgeted_amount, actual_spend, notes. Explicit exclusions: no
+  imputing or interpolating null actual_spend values from neighbouring periods;
+  no filling gaps with budgeted_amount; no aggregating across wards or across
+  categories; no annualising partial years; no outside knowledge about the
+  wards or municipal spending patterns; no redefining the growth formula after
+  seeing the numbers.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Scope lock: computations are allowed only for the exact ward string and exact category string requested, both validated against the values present in the input file. Requests for 'all wards', 'all categories', totals, averages, or any cross-ward/cross-category combination are refused — state that per-ward per-category queries only are supported."
+  - "Null rule: every row whose actual_spend is blank is flagged NULL_SPEND with the reason copied verbatim from its notes column BEFORE any computation happens, and is excluded from being a growth operand — never skipped silently, never imputed, never treated as zero."
+  - "Formula rule: every computed row carries a formula field showing the calculation with substituted values, e.g. '(19.7 − 14.8) / 14.8 × 100 = +33.1%', using the declared growth type's definition."
+  - "Formula-choice refusal: if no growth type was specified, refuse and ask the user to choose from the supported types (MoM = month-over-month vs previous month; YoY = vs same month previous year). Never default to either."
+  - "Refusal condition: if the requested ward or category does not exist in the input file, refuse with the list of valid values instead of guessing the closest match; if the input file is missing required columns or contains zero parseable rows, refuse rather than producing an empty or partial table."

--- a/uc-0c/app.py
+++ b/uc-0c/app.py
@@ -1,12 +1,229 @@
 """
-UC-0C app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-0C — Number That Looks Right
+Deterministic ward-level budget growth calculator. Implements the contracts
+defined in agents.md and skills.md: strict single-ward single-category scope,
+explicit flagging of every null actual_spend with its notes reason, formula
+shown on every computed row, and refusal to guess an unspecified growth type.
 """
 import argparse
+import csv
+import sys
+
+REQUIRED_COLUMNS = ("period", "ward", "category", "budgeted_amount", "actual_spend", "notes")
+OUTPUT_COLUMNS = (
+    "period", "ward", "category", "budgeted_amount", "actual_spend",
+    "growth_type", "growth_pct", "formula", "flag", "notes",
+)
+GROWTH_TYPES = {"mom": "MoM", "yoy": "YoY"}
+AGGREGATION_REQUESTS = {"all", "*", "total", "totals", "aggregate", "combined", "overall"}
+
+FLAG_NO_PRIOR = "NO_PRIOR_PERIOD"
+FLAG_NULL_CURRENT = "NULL_SPEND"
+FLAG_NULL_PRIOR = "PRIOR_SPEND_NULL"
+FLAG_ZERO_PRIOR = "PRIOR_SPEND_ZERO"
+FLAG_UNPARSEABLE = "UNPARSEABLE_SPEND"
+
+
+def load_dataset(path):
+    """Read the budget CSV; validate columns; report nulls before returning."""
+    try:
+        input_file = open(path, newline="", encoding="utf-8")
+    except OSError as exc:
+        sys.exit(f"error: cannot read input file '{path}': {exc}")
+
+    with input_file:
+        reader = csv.DictReader(input_file)
+        fieldnames = reader.fieldnames or []
+        missing = [c for c in REQUIRED_COLUMNS if c not in fieldnames]
+        if missing:
+            sys.exit(f"error: input CSV is missing required columns: {', '.join(missing)}")
+        rows = []
+        for line_no, row in enumerate(reader, start=2):
+            row["_line"] = line_no
+            rows.append(row)
+
+    if not rows:
+        sys.exit("error: input CSV contains no data rows")
+
+    known_wards = sorted({r["ward"].strip() for r in rows})
+    known_categories = sorted({r["category"].strip() for r in rows})
+    null_report = [
+        {
+            "line": r["_line"],
+            "period": r["period"].strip(),
+            "ward": r["ward"].strip(),
+            "category": r["category"].strip(),
+            "notes": r["notes"].strip(),
+        }
+        for r in rows if not r["actual_spend"].strip()
+    ]
+    return rows, known_wards, known_categories, null_report
+
+
+def _prior_period(period, growth_type):
+    year, month = int(period[:4]), int(period[5:7])
+    if growth_type == "MoM":
+        month -= 1
+        if month == 0:
+            year, month = year - 1, 12
+    else:
+        year -= 1
+    return f"{year:04d}-{month:02d}"
+
+
+def _row(ward, category, period, budget, spend_raw, growth_type):
+    return {
+        "period": period,
+        "ward": ward,
+        "category": category,
+        "budgeted_amount": budget,
+        "actual_spend": spend_raw if spend_raw else "NULL",
+        "growth_type": growth_type,
+        "growth_pct": "",
+        "formula": "",
+        "flag": "",
+        "notes": "",
+    }
+
+
+def compute_growth(rows, ward, category, growth_type):
+    """Return one output row per period for the requested ward+category slice."""
+    series = {}
+    for r in rows:
+        if r["ward"].strip() == ward and r["category"].strip() == category:
+            series[r["period"].strip()] = r
+
+    table = []
+    for period in sorted(series):
+        r = series[period]
+        budget = r["budgeted_amount"].strip()
+        spend_raw = r["actual_spend"].strip()
+        note = r["notes"].strip()
+        out = _row(ward, category, period, budget, spend_raw, growth_type)
+        out["notes"] = note
+
+        if not spend_raw:
+            out["flag"] = FLAG_NULL_CURRENT
+            out["notes"] = note or "reason not recorded"
+            table.append(out)
+            continue
+
+        try:
+            cur = float(spend_raw)
+        except ValueError:
+            out["flag"] = FLAG_UNPARSEABLE
+            out["notes"] = (note + "; " if note else "") + f"actual_spend {spend_raw!r} is not a number"
+            table.append(out)
+            continue
+
+        prior_period = _prior_period(period, growth_type)
+        prior = series.get(prior_period)
+        if prior is None:
+            out["flag"] = FLAG_NO_PRIOR
+            out["notes"] = note or f"no {prior_period} row exists for this ward+category"
+            table.append(out)
+            continue
+
+        prior_raw = prior["actual_spend"].strip()
+        if not prior_raw:
+            prior_note = prior["notes"].strip() or "reason not recorded"
+            out["flag"] = FLAG_NULL_PRIOR
+            out["notes"] = f"{prior_period} actual_spend is NULL ({prior_note}) — not computed"
+            table.append(out)
+            continue
+
+        try:
+            prev = float(prior_raw)
+        except ValueError:
+            out["flag"] = FLAG_UNPARSEABLE
+            out["notes"] = f"{prior_period} actual_spend {prior_raw!r} is not a number"
+            table.append(out)
+            continue
+
+        if prev == 0:
+            out["flag"] = FLAG_ZERO_PRIOR
+            out["notes"] = f"growth undefined: {prior_period} actual_spend is 0"
+            table.append(out)
+            continue
+
+        pct = round((cur - prev) / prev * 100, 1)
+        out["growth_pct"] = f"{pct:+.1f}%"
+        out["formula"] = f"({cur:g} − {prev:g}) / {prev:g} × 100 = {pct:+.1f}%"
+        table.append(out)
+
+    return table
+
+
+def _refuse_aggregation(value, kind):
+    sys.exit(
+        f"refused: '{value}' is not a single {kind}. This tool computes growth for "
+        f"exactly one {kind} at a time and never aggregates across wards or "
+        "categories. Pass one of the exact values listed by this tool."
+    )
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-0C Budget Growth Analyser")
+    parser.add_argument("--input", required=True, help="Path to ward_budget.csv")
+    parser.add_argument("--ward", required=True, help="Exact ward name from the dataset")
+    parser.add_argument("--category", required=True, help="Exact category name from the dataset")
+    parser.add_argument("--growth-type", default=None, help="MoM or YoY — no default is assumed")
+    parser.add_argument("--output", required=True, help="Path to write growth_output.csv")
+    args = parser.parse_args()
+
+    if not args.growth_type or not args.growth_type.strip():
+        sys.exit(
+            "refused: no growth type specified. Choose explicitly: "
+            "--growth-type MoM (vs previous month) or --growth-type YoY "
+            "(vs same month previous year). Never guessed."
+        )
+    growth_key = args.growth_type.strip().lower()
+    if growth_key not in GROWTH_TYPES:
+        sys.exit(
+            f"refused: unknown growth type '{args.growth_type}'. "
+            f"Supported types: MoM, YoY."
+        )
+    growth_type = GROWTH_TYPES[growth_key]
+
+    rows, known_wards, known_categories, null_report = load_dataset(args.input)
+
+    print(f"Loaded {len(rows)} rows | {len(known_wards)} wards x "
+          f"{len(known_categories)} categories | periods "
+          f"{min(r['period'] for r in rows)} .. {max(r['period'] for r in rows)}")
+
+    print(f"Null audit BEFORE computing: {len(null_report)} blank actual_spend row(s)")
+    for n in null_report:
+        print(f"  - line {n['line']}: {n['period']} | {n['ward']} | "
+              f"{n['category']} | reason: {n['notes'] or 'not recorded'}")
+
+    if args.ward.strip().lower() in AGGREGATION_REQUESTS:
+        _refuse_aggregation(args.ward.strip(), "ward")
+    if args.category.strip().lower() in AGGREGATION_REQUESTS:
+        _refuse_aggregation(args.category.strip(), "category")
+
+    if args.ward.strip() not in known_wards:
+        sys.exit(
+            f"refused: ward {args.ward!r} not found. Valid wards:\n  "
+            + "\n  ".join(known_wards)
+        )
+    if args.category.strip() not in known_categories:
+        sys.exit(
+            f"refused: category {args.category!r} not found. Valid categories:\n  "
+            + "\n  ".join(known_categories)
+        )
+
+    table = compute_growth(rows, args.ward.strip(), args.category.strip(), growth_type)
+
+    computed = sum(1 for t in table if t["formula"])
+    flagged = len(table) - computed
+    with open(args.output, "w", newline="", encoding="utf-8") as out_file:
+        writer = csv.DictWriter(out_file, fieldnames=OUTPUT_COLUMNS)
+        writer.writeheader()
+        writer.writerows(table)
+
+    print(f"Wrote {args.output}: {len(table)} rows | {computed} computed | "
+          f"{flagged} flagged (never silently skipped)")
+
 
 if __name__ == "__main__":
     main()

--- a/uc-0c/growth_output.csv
+++ b/uc-0c/growth_output.csv
@@ -1,0 +1,13 @@
+period,ward,category,budgeted_amount,actual_spend,growth_type,growth_pct,formula,flag,notes
+2024-01,Ward 1 – Kasba,Roads & Pothole Repair,13.0,13.3,MoM,,,NO_PRIOR_PERIOD,no 2023-12 row exists for this ward+category
+2024-02,Ward 1 – Kasba,Roads & Pothole Repair,13.0,12.2,MoM,-8.3%,(12.2 − 13.3) / 13.3 × 100 = -8.3%,,
+2024-03,Ward 1 – Kasba,Roads & Pothole Repair,13.0,12.3,MoM,+0.8%,(12.3 − 12.2) / 12.2 × 100 = +0.8%,,
+2024-04,Ward 1 – Kasba,Roads & Pothole Repair,13.0,13.4,MoM,+8.9%,(13.4 − 12.3) / 12.3 × 100 = +8.9%,,
+2024-05,Ward 1 – Kasba,Roads & Pothole Repair,13.0,14.1,MoM,+5.2%,(14.1 − 13.4) / 13.4 × 100 = +5.2%,,
+2024-06,Ward 1 – Kasba,Roads & Pothole Repair,13.0,14.8,MoM,+5.0%,(14.8 − 14.1) / 14.1 × 100 = +5.0%,,
+2024-07,Ward 1 – Kasba,Roads & Pothole Repair,13.0,19.7,MoM,+33.1%,(19.7 − 14.8) / 14.8 × 100 = +33.1%,,
+2024-08,Ward 1 – Kasba,Roads & Pothole Repair,13.0,20.2,MoM,+2.5%,(20.2 − 19.7) / 19.7 × 100 = +2.5%,,
+2024-09,Ward 1 – Kasba,Roads & Pothole Repair,13.0,20.1,MoM,-0.5%,(20.1 − 20.2) / 20.2 × 100 = -0.5%,,
+2024-10,Ward 1 – Kasba,Roads & Pothole Repair,13.0,13.1,MoM,-34.8%,(13.1 − 20.1) / 20.1 × 100 = -34.8%,,
+2024-11,Ward 1 – Kasba,Roads & Pothole Repair,13.0,14.2,MoM,+8.4%,(14.2 − 13.1) / 13.1 × 100 = +8.4%,,
+2024-12,Ward 1 – Kasba,Roads & Pothole Repair,13.0,12.7,MoM,-10.6%,(12.7 − 14.2) / 14.2 × 100 = -10.6%,,

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0C Budget Growth Analyser
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: Reads the ward budget CSV, validates its structure, and reports every null actual_spend row with its notes reason before any computation happens.
+    input: Path to a UTF-8 CSV with the required columns period (YYYY-MM), ward, category, budgeted_amount, actual_spend (float or blank), notes.
+    output: The parsed rows plus three derived artefacts — the sorted list of distinct ward strings, the sorted list of distinct category strings, and a null report (count + period/ward/category/notes for each blank actual_spend).
+    error_handling: A missing or unreadable file, or missing required columns, aborts with a clear error before anything is processed; blank actual_spend is recorded in the null report, not treated as zero; unparseable numeric values are flagged per-row instead of crashing.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: compute_growth
+    description: Computes the growth series for exactly one ward and one category using the requested growth type, returning a per-period table where every row shows its formula or its flag.
+    input: The loaded dataset rows, an exact ward string, an exact category string, and a growth type — MoM (vs previous month) or YoY (vs same month previous year); the ward and category must match dataset values exactly.
+    output: One row per period containing period, ward, category, budgeted_amount, actual_spend, growth_type, growth_pct (1 decimal, signed), formula (with substituted values), flag, and notes. Rows that cannot be computed carry one of NO_PRIOR_PERIOD (first month / no prior year), NULL_SPEND (this row's spend is null, reason from notes), PRIOR_SPEND_NULL (comparison operand was null, reason from prior row's notes), PRIOR_SPEND_ZERO (growth undefined against a zero operand), or UNPARSEABLE_SPEND — with growth_pct and formula left empty.
+    error_handling: Refuses rather than guesses when growth type is absent from the input or not one of MoM/YoY, when the ward or category is not an exact dataset value (returns the valid options), and when the request spans multiple wards/categories; never imputes nulls, never substitutes budgeted_amount for actual_spend, and leaves uncomputable rows visibly flagged.

--- a/uc-x/agents.md
+++ b/uc-x/agents.md
@@ -1,18 +1,50 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-X Ask My Documents
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Single-source policy question-answering agent over exactly three supplied
+  documents — ../data/policy-documents/policy_hr_leave.txt,
+  ../data/policy-documents/policy_it_acceptable_use.txt and
+  ../data/policy-documents/policy_finance_reimbursement.txt. Given one employee
+  question, it returns either an answer drawn from ONE document, quoting that
+  document's own text with filename and section number cited, or the fixed
+  refusal template below. Its operational boundary ends at retrieving and
+  attributing existing policy text — it does not advise, interpret, reconcile
+  policies, predict what a policy "would" say, or combine documents.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  A correct interaction is mechanically verifiable:
+  1. every factual answer quotes or restates text from exactly one document and
+     carries a citation of the form (policy_<name>.txt, section N.M);
+  2. no answer ever merges claims from two documents — a question whose signals
+     point at more than one document with comparable strength is refused, not
+     blended;
+  3. every obligation condition survives intact — an answer naming approvers
+     names ALL required approvers, a limit keeps its exact number and deadline,
+     an eligibility rule keeps its eligible group;
+  4. questions not covered by any document receive the refusal template
+     verbatim, never a hedged guess;
+  5. no output ever contains hedging language of any kind.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent may use only the text of the three supplied policy documents.
+  Explicit exclusions: no outside knowledge of company practice, employment
+  law, or how such policies usually work; no inference of permissions the
+  source text does not grant; no combining the IT personal-device rules with
+  HR leave or finance work-from-home provisions — the personal-phone-from-home
+  question is answered from IT section 3.1 alone (CMC email and the employee
+  self-service portal only) or refused, never blended into a permission that
+  exists in neither document; no softening of "must", "requires",
+  "not permitted", "only"; no dropping of numeric limits, deadlines, eligible
+  groups, or named approvers; no hedging phrases in any output.
+
+refusal_template: |
+  This question is not covered in the available policy documents
+  (policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt).
+  Please contact [relevant team] for guidance.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Single-source rule: one answer draws on exactly one document. If the highest-scoring evidence for a question exists in two or more documents with comparable strength (runner-up document reaching 75% of the leader's score), treat the question as ambiguous across documents and issue the refusal template — never blend claims from two documents into a single answer."
+  - "Citation rule: every factual claim in an answer is followed by a citation of the source document filename and section number, e.g. (policy_it_acceptable_use.txt, section 3.1). An answer without a citation is invalid."
+  - "Condition-preservation rule: quoted or condensed policy text retains ALL qualifiers — numeric limits (e.g. Rs 8,000, 5 days), deadlines (e.g. forfeited on 31 December), eligible groups (e.g. permanent work-from-home only), and EVERY named approver (HR section 5.2 requires BOTH the Department Head AND the HR Director — dropping either invalidates the answer). Verbatim quotation of the source section is the default mechanism."
+  - "Hedging ban: the phrases 'while not explicitly covered', 'typically', 'generally understood', 'it is common practice', 'generally expected' must never appear in any output. Any drafted answer containing them is discarded and replaced by the refusal template."
+  - "Refusal condition: if no section reaches the evidence threshold, or coverage is genuinely cross-document under the single-source rule, respond with refusal_template EXACTLY as written above — no variations, no added sentences — resolving the single placeholder [relevant team] deterministically to the owning team of the closest-matching document: policy_hr_leave.txt maps to HR Department, policy_it_acceptable_use.txt maps to IT Helpdesk, policy_finance_reimbursement.txt maps to Finance Department; when no document signals at all, default to HR Department. Never improvise alternative refusals."

--- a/uc-x/app.py
+++ b/uc-x/app.py
@@ -1,12 +1,298 @@
 """
-UC-X app.py — Starter file.
-Build this using the RICE + agents.md + skills.md + CRAFT workflow.
-See README.md for run command and expected behaviour.
+UC-X — Ask My Documents
+Deterministic single-source policy Q&A over exactly three CMC policy documents.
+Implements the agents.md contracts: one answer draws on ONE document and cites
+filename + section number, conditions survive verbatim, cross-document
+ambiguity (runner-up >= 75% of leader) refuses instead of blending, uncovered
+questions get the refusal template verbatim with [relevant team] resolved
+deterministically, and a hedging-ban scan vets every rendered answer.
 """
 import argparse
+import math
+import os
+import re
+import sys
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_DATA_DIR = os.path.join(BASE_DIR, "..", "data", "policy-documents")
+
+DOC_FILES = (
+    "policy_hr_leave.txt",
+    "policy_it_acceptable_use.txt",
+    "policy_finance_reimbursement.txt",
+)
+DOC_TEAM = {
+    "policy_hr_leave.txt": "HR Department",
+    "policy_it_acceptable_use.txt": "IT Helpdesk",
+    "policy_finance_reimbursement.txt": "Finance Department",
+}
+DEFAULT_TEAM = "HR Department"
+
+REFUSAL_TEMPLATE = (
+    "This question is not covered in the available policy documents\n"
+    "(policy_hr_leave.txt, policy_it_acceptable_use.txt, "
+    "policy_finance_reimbursement.txt).\n"
+    "Please contact [relevant team] for guidance."
+)
+
+HEDGING_PHRASES = (
+    "while not explicitly covered",
+    "typically",
+    "generally understood",
+    "it is common practice",
+    "generally expected",
+)
+
+CITATION_RE = re.compile(r"\(policy_[a-z_]+\.txt, section \d+\.\d+\)")
+SEPARATOR_RE = re.compile(r"^\s*[═=]{3,}\s*$")
+CLAUSE_RE = re.compile(r"^(\d+\.\d+)\s+(.*)$")
+WORD_RE = re.compile(r"[a-z0-9]+")
+
+MIN_EVIDENCE = 2.8
+RUNNER_UP_RATIO = 0.75
+RUNNER_MIN_COVERAGE = 0.6
+
+STOPWORDS = frozenset("""
+a an the and or but if then else when while of to in on at by for with from as
+is are was were be been being am do does did doing have has had having i me my
+mine we us our ours you your yours he him his she her hers it its this that
+these those they them their theirs what which who whom whose where why how
+will would shall should can could may might must not no nor so than too very
+just about there here also into per any all each own s t don ain
+""".split())
+
+CANONICAL = {
+    "approval": "approv", "approvals": "approv", "approve": "approv",
+    "approves": "approv", "approved": "approv", "approving": "approv",
+    "carried": "carry", "carries": "carry",
+    "entitled": "entitle", "entitlement": "entitle", "entitlements": "entitle",
+    "eligibility": "eligible",
+    "forfeiture": "forfeit", "forfeited": "forfeit",
+    "encashment": "encash",
+    "reimbursement": "reimburse", "reimbursements": "reimburse",
+    "reimbursable": "reimburse", "reimbursed": "reimburse",
+    "submission": "submit", "submitted": "submit", "submits": "submit",
+    "installation": "install", "installing": "install", "installed": "install",
+}
+
+VERBS = frozenset((
+    "approv", "carry", "claim", "chang", "connect", "encash", "forward",
+    "install", "print", "reimburse", "report", "share", "submit",
+))
+
+APPROVAL_QUERY_RE = re.compile(r"^\s*who\b|\bwhich\s+(?:team|department|person|role)s?\b")
+
+
+def canonicalise(word):
+    if word in CANONICAL:
+        return CANONICAL[word]
+    if word.endswith("ies") and len(word) > 4:
+        return word[:-3] + "y"
+    for suffix in ("ing", "ed", "es", "s"):
+        if word.endswith(suffix) and len(word) - len(suffix) >= 3:
+            return word[: len(word) - len(suffix)]
+    return word
+
+
+def tokenize(text):
+    return [
+        canonicalise(w)
+        for w in WORD_RE.findall(text.lower())
+        if len(w) >= 2 and w not in STOPWORDS
+    ]
+
+
+class Clause(object):
+    def __init__(self, doc, sid, text, heading):
+        self.doc = doc
+        self.sid = sid
+        self.text = text
+        self.heading = heading
+        self.vocab = set(tokenize(text)) | set(tokenize(heading))
+
+
+def load_documents(data_dir):
+    """retrieve_documents skill: index every clause by filename + section id."""
+    index = {}
+    for fname in DOC_FILES:
+        path = os.path.join(data_dir, fname)
+        try:
+            with open(path, encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as exc:
+            sys.exit("error: cannot read policy document '%s': %s" % (path, exc))
+        clauses = []
+        heading = ""
+        cur_sid = None
+        cur_lines = []
+
+        def flush():
+            if cur_sid is not None:
+                clauses.append(Clause(fname, cur_sid, " ".join(cur_lines), heading))
+
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if SEPARATOR_RE.match(stripped):
+                flush()
+                cur_sid = None
+                cur_lines = []
+                continue
+            match = CLAUSE_RE.match(stripped)
+            if match:
+                flush()
+                cur_sid = match.group(1)
+                cur_lines = [match.group(2)]
+                continue
+            if not stripped:
+                continue
+            if cur_sid is None:
+                heading = stripped
+            else:
+                cur_lines.append(stripped)
+        flush()
+
+        if not clauses:
+            sys.exit(
+                "error: no numbered sections parsed from '%s' — refusing to "
+                "answer from a partial corpus" % path
+            )
+        index[fname] = clauses
+
+    total = sum(len(c) for c in index.values())
+    df = {}
+    for clauses in index.values():
+        for clause in clauses:
+            for term in clause.vocab:
+                df[term] = df.get(term, 0) + 1
+    return index, total, df
+
+
+def idf(df, total_clauses, term):
+    hits = df.get(term, 0)
+    if hits == 0:
+        return 0.0
+    return math.log(1.0 + float(total_clauses) / hits)
+
+
+def refusal_text(team):
+    resolved = DOC_TEAM.get(team)
+    if resolved is None and team in DOC_TEAM.values():
+        resolved = team
+    return REFUSAL_TEMPLATE.replace("[relevant team]", resolved or DEFAULT_TEAM)
+
+
+def render_answer(clause):
+    """Condition-preservation by construction: verbatim quote + citation."""
+    body = 'A: "%s" (%s, section %s)' % (clause.text, clause.doc, clause.sid)
+    lowered = body.lower()
+    for phrase in HEDGING_PHRASES:
+        if phrase in lowered:
+            return refusal_text(clause.doc)
+    if not CITATION_RE.search(body):
+        return refusal_text(clause.doc)
+    return body
+
+
+def answer_question(question, index, total_clauses, df):
+    """answer_question skill: score, single-source gate, answer or refuse."""
+    seen = set()
+    qtokens = []
+    unseen_terms = 0
+    for word in WORD_RE.findall(question.lower()):
+        if len(word) < 3 or word in STOPWORDS:
+            continue
+        term = canonicalise(word)
+        if term in seen:
+            continue
+        seen.add(term)
+        weight = idf(df, total_clauses, term)
+        if weight > 0.0:
+            qtokens.append((term, weight))
+        elif word.isalpha():
+            unseen_terms += 1
+
+    if not qtokens:
+        return refusal_text(None)
+
+    approval_routing = (bool(APPROVAL_QUERY_RE.search(question))
+                        and "approv" in seen)
+    shared_verb_bonus = 0.0
+    if unseen_terms:
+        question_verbs = seen & VERBS
+        if question_verbs:
+            shared_verb_bonus = math.log(1.0 + float(total_clauses))
+
+    best_per_doc = {}
+    for doc in DOC_FILES:
+        doc_best = None
+        for clause in index[doc]:
+            if approval_routing and "approv" not in clause.vocab:
+                continue
+            matched = [(t, w) for t, w in qtokens if t in clause.vocab]
+            if not matched:
+                continue
+            smax = max(w for _, w in matched)
+            ssum = sum(w for _, w in matched)
+            n = len(matched)
+            if shared_verb_bonus and question_verbs & clause.vocab:
+                smax = max(smax, shared_verb_bonus)
+                ssum += shared_verb_bonus
+            cand = (smax, ssum, n, clause)
+            if doc_best is None or cand[:3] > doc_best[:3]:
+                doc_best = cand
+        if doc_best is not None:
+            best_per_doc[doc] = doc_best
+
+    if not best_per_doc:
+        return refusal_text(None)
+
+    ranked = sorted(best_per_doc.items(), key=lambda kv: kv[1][:3], reverse=True)
+    leader_doc, leader = ranked[0]
+    leader_ssum = leader[1]
+
+    if leader_ssum < MIN_EVIDENCE:
+        return refusal_text(leader_doc)
+
+    if len(ranked) > 1:
+        runner = ranked[1][1]
+        comparable = (runner[2] >= RUNNER_MIN_COVERAGE * leader[2]
+                      and runner[1] >= RUNNER_UP_RATIO * leader_ssum)
+        if comparable:
+            return refusal_text(leader_doc)
+
+    return render_answer(leader[3])
+
 
 def main():
-    raise NotImplementedError("Build this using your AI tool + RICE prompt")
+    parser = argparse.ArgumentParser(description="UC-X Ask My Documents")
+    parser.add_argument("--data-dir", default=DEFAULT_DATA_DIR,
+                        help="Directory containing the three policy documents")
+    parser.add_argument("--ask", default=None,
+                        help="Ask one question non-interactively and exit")
+    args = parser.parse_args()
+
+    index, total_clauses, df = load_documents(args.data_dir)
+
+    if args.ask is not None:
+        print(answer_question(args.ask, index, total_clauses, df))
+        return
+
+    print("UC-X — Ask My Documents")
+    print("Indexed %d sections across %d documents: %s"
+          % (total_clauses, len(DOC_FILES), ", ".join(DOC_FILES)))
+    print("Type a question about CMC policy, or 'quit' to exit.")
+    while True:
+        try:
+            line = input("Q> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("")
+            break
+        if not line:
+            continue
+        if line.lower() in ("quit", "exit"):
+            break
+        print(answer_question(line, index, total_clauses, df))
+
 
 if __name__ == "__main__":
     main()

--- a/uc-x/app.py
+++ b/uc-x/app.py
@@ -6,6 +6,16 @@ filename + section number, conditions survive verbatim, cross-document
 ambiguity (runner-up >= 75% of leader) refuses instead of blending, uncovered
 questions get the refusal template verbatim with [relevant team] resolved
 deterministically, and a hedging-ban scan vets every rendered answer.
+Retrieval relevance: symmetric stemming so inflected forms of a word always
+converge to one stem (previously "leaves" stemmed to "leav" while clauses
+containing "leave" kept a different stem, letting one mismatched keyword
+pull an irrelevant clause ahead), rarity-weighted evidence sums rank answers,
+a leader needs at least two corroborating query terms so one stray keyword
+can never decide a topic alone, and exact-score ties inside a document
+resolve by section order — any section of the same document is a valid
+single source — instead of dropping the whole document (previously a tie
+among one-term matches silently discarded the correct document and let a
+weak keyword from another document win).
 """
 import argparse
 import math
@@ -52,6 +62,11 @@ MIN_EVIDENCE = 2.8
 RUNNER_UP_RATIO = 0.75
 RUNNER_MIN_COVERAGE = 0.6
 
+ANCHOR_MIN_DF = 8
+ANCHOR_DOC_SHARE = 0.7
+QUANTITY_QUERY_RE = re.compile(r"\bhow\s+(?:many|much)\b")
+DIGIT_RE = re.compile(r"\d")
+
 STOPWORDS = frozenset("""
 a an the and or but if then else when while of to in on at by for with from as
 is are was were be been being am do does did doing have has had having i me my
@@ -75,23 +90,34 @@ CANONICAL = {
     "installation": "install", "installing": "install", "installed": "install",
 }
 
-VERBS = frozenset((
+
+def _raw_stem(word):
+    changed = True
+    while changed:
+        changed = False
+        for suffix in ("ing", "ed", "es", "s"):
+            if word.endswith(suffix) and len(word) - len(suffix) >= 3:
+                word = word[: len(word) - len(suffix)]
+                changed = True
+                break
+    if len(word) >= 4 and word.endswith("e"):
+        word = word[:-1]
+    return word
+
+
+def canonicalise(word):
+    base = CANONICAL.get(word, word)
+    if base.endswith("ies") and len(base) > 4:
+        base = base[:-3] + "y"
+    return _raw_stem(base)
+
+
+VERBS = frozenset(canonicalise(v) for v in (
     "approv", "carry", "claim", "chang", "connect", "encash", "forward",
     "install", "print", "reimburse", "report", "share", "submit",
 ))
 
 APPROVAL_QUERY_RE = re.compile(r"^\s*who\b|\bwhich\s+(?:team|department|person|role)s?\b")
-
-
-def canonicalise(word):
-    if word in CANONICAL:
-        return CANONICAL[word]
-    if word.endswith("ies") and len(word) > 4:
-        return word[:-3] + "y"
-    for suffix in ("ing", "ed", "es", "s"):
-        if word.endswith(suffix) and len(word) - len(suffix) >= 3:
-            return word[: len(word) - len(suffix)]
-    return word
 
 
 def tokenize(text):
@@ -108,7 +134,8 @@ class Clause(object):
         self.sid = sid
         self.text = text
         self.heading = heading
-        self.vocab = set(tokenize(text)) | set(tokenize(heading))
+        self.heading_vocab = set(tokenize(heading))
+        self.vocab = set(tokenize(text)) | self.heading_vocab
 
 
 def load_documents(data_dir):
@@ -194,7 +221,29 @@ def render_answer(clause):
 
 
 def answer_question(question, index, total_clauses, df):
-    """answer_question skill: score, single-source gate, answer or refuse."""
+    """answer_question skill: score, single-source gate, answer or refuse.
+
+    Evidence score is the sum of matched term idfs; section headings
+    contribute their words to the clause vocabulary, so heading matches
+    count like body matches. Symmetric stemming guarantees inflected query
+    words match the index at all. A leader must clear MIN_EVIDENCE with at
+    least TWO corroborating query terms: a single keyword — however rare —
+    is never coverage on its own, but when the question also carries words
+    the corpus lacks (product names, typos), a corpus-known action verb in
+    the clause counts as the second term, keeping "install <unknown app>"
+    retrievable while a stray keyword like "office" cannot hijack the
+    answer. "wfh" is expanded to work-from-home vocabulary before matching.
+    A how-many/much question whose sole corpus evidence is one document-
+    dominant topic term (e.g. "leave", which appears almost exclusively in
+    the HR policy) resolves inside that owning document — preferring its
+    first clause that states a figure — instead of refusing: concentration,
+    not raw score, proves ownership there. Exact-score ties inside one
+    document are resolved by section order — any section of the same
+    document is a valid single-source answer; only cross-document ambiguity
+    triggers refusal.
+    """
+    question = re.sub(r"\bwfh\b", "work from home", question,
+                      flags=re.IGNORECASE)
     seen = set()
     qtokens = []
     unseen_terms = 0
@@ -216,11 +265,12 @@ def answer_question(question, index, total_clauses, df):
 
     approval_routing = (bool(APPROVAL_QUERY_RE.search(question))
                         and "approv" in seen)
-    shared_verb_bonus = 0.0
+    verb_bonus = 0.0
+    question_verbs = set()
     if unseen_terms:
         question_verbs = seen & VERBS
         if question_verbs:
-            shared_verb_bonus = math.log(1.0 + float(total_clauses))
+            verb_bonus = math.log(1.0 + float(total_clauses))
 
     best_per_doc = {}
     for doc in DOC_FILES:
@@ -228,39 +278,56 @@ def answer_question(question, index, total_clauses, df):
         for clause in index[doc]:
             if approval_routing and "approv" not in clause.vocab:
                 continue
+            verb_hit = bool(verb_bonus) and bool(question_verbs & clause.vocab)
             matched = [(t, w) for t, w in qtokens if t in clause.vocab]
-            if not matched:
+            if not matched and not verb_hit:
                 continue
-            smax = max(w for _, w in matched)
+            smax = max(w for _, w in matched) if matched else 0.0
             ssum = sum(w for _, w in matched)
             n = len(matched)
-            if shared_verb_bonus and question_verbs & clause.vocab:
-                smax = max(smax, shared_verb_bonus)
-                ssum += shared_verb_bonus
-            cand = (smax, ssum, n, clause)
+            if verb_hit:
+                smax = max(smax, verb_bonus)
+                ssum += verb_bonus
+                n += 1
+            terms = frozenset(t for t, _ in matched)
+            cand = (ssum, smax, n, terms, clause)
             if doc_best is None or cand[:3] > doc_best[:3]:
                 doc_best = cand
-        if doc_best is not None:
-            best_per_doc[doc] = doc_best
+        if doc_best is None:
+            continue
+        best_per_doc[doc] = doc_best
 
     if not best_per_doc:
         return refusal_text(None)
 
     ranked = sorted(best_per_doc.items(), key=lambda kv: kv[1][:3], reverse=True)
     leader_doc, leader = ranked[0]
-    leader_ssum = leader[1]
+    leader_ssum = leader[0]
 
-    if leader_ssum < MIN_EVIDENCE:
+    if leader[2] == 1 and leader[3] and QUANTITY_QUERY_RE.search(question):
+        anchor = next(iter(leader[3]))
+        hits = df.get(anchor, 0)
+        owner_clauses = index[leader_doc]
+        in_owner = sum(1 for c in owner_clauses if anchor in c.vocab)
+        if hits >= ANCHOR_MIN_DF and in_owner >= ANCHOR_DOC_SHARE * hits:
+            pool = [c for c in owner_clauses
+                    if anchor in c.vocab
+                    and not (approval_routing and "approv" not in c.vocab)]
+            chosen = next((c for c in pool if DIGIT_RE.search(c.text)),
+                          pool[0])
+            return render_answer(chosen)
+
+    if leader_ssum < MIN_EVIDENCE or leader[2] < 2:
         return refusal_text(leader_doc)
 
     if len(ranked) > 1:
         runner = ranked[1][1]
         comparable = (runner[2] >= RUNNER_MIN_COVERAGE * leader[2]
-                      and runner[1] >= RUNNER_UP_RATIO * leader_ssum)
+                      and runner[0] >= RUNNER_UP_RATIO * leader_ssum)
         if comparable:
             return refusal_text(leader_doc)
 
-    return render_answer(leader[3])
+    return render_answer(leader[4])
 
 
 def main():

--- a/uc-x/skills.md
+++ b/uc-x/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-X Ask My Documents
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_documents
+    description: Loads the three CMC policy files and indexes every numbered section by document filename and section number so any passage can be retrieved and cited exactly.
+    input: None — fixed corpus paths ../data/policy-documents/policy_hr_leave.txt, ../data/policy-documents/policy_it_acceptable_use.txt, ../data/policy-documents/policy_finance_reimbursement.txt (UTF-8 plain text with N.M-numbered sections under numbered headings).
+    output: An index mapping each document filename to its sections (section id "N.M" to verbatim section text), plus the loaded filename list used to build citations of the form (policy_<name>.txt, section N.M).
+    error_handling: A missing, unreadable, or empty file aborts with a clear error naming the file — the system never answers from a partial corpus; a file that yields zero parseable numbered sections is a load failure, not silently skipped.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: answer_question
+    description: Scores one employee question against the section index and returns either a single-document verbatim answer with its citation, or the fixed refusal template — never a blend, never a hedge.
+    input: One free-text question string typed at the interactive prompt, e.g. "Who approves leave without pay?".
+    output: An answer block quoting policy text VERBATIM from exactly ONE document followed by its citation (policy_<name>.txt, section N.M), with every numeric limit, deadline, eligible group, and ALL required approvers preserved — OR the refusal template from agents.md with [relevant team] resolved deterministically to HR Department, IT Helpdesk, or Finance Department.
+    error_handling: Empty or blank input is re-prompted, never answered; if no section reaches the evidence threshold, or the runner-up document scores ≥ 75% of the leader (cross-document ambiguity), the refusal template is issued instead of guessing; any drafted output containing a banned hedging phrase is discarded and replaced by the refusal template; unknown terms never draw on outside knowledge.


### PR DESCRIPTION
**UC-0A — Grievance Classifier** ([7eb33c2](https://github.com/nasscomAI/prompt-to-production/pull/1978/commits/7eb33c2fd516b809a47ceebf8c89ed22f1a171fa))
Replaced a naive prompt that produced inconsistent categories, missed injury/child/school keywords, and guessed confidently on ambiguous rows with a deterministic rules-based classifier: exact 10-category taxonomy, keyword-driven Urgent priority, description-cited justifications, and NEEDS_REVIEW flags on ambiguity.

**UC-0B — Policy Summariser** ([70b3bb3](https://github.com/nasscomAI/prompt-to-production/pull/1978/commits/70b3bb32e6fd9b9a120dd54c00b9c912cdcc234b), [2021e7c](https://github.com/nasscomAI/prompt-to-production/pull/1978/commits/2021e7c797e3e5aebc79b6a90cab92641481c8f9))
Fixed summarisation that dropped clauses/conditions and invented standard-practice content: the summariser now parses every clause from source and re-verifies all quantities/approvers/binding verbs in condensed text, falling back to verbatim quotes flagged FLAGGED. Second commit fixed a Python 3.9 SyntaxError (backslash in f-string) that broke CI.

**UC-0C — Spend Growth Calculator** ([6856582](https://github.com/nasscomAI/prompt-to-production/pull/1978/commits/6856582491aa537f5a6662cb945104654a9bb0e4))
Fixed wrong aggregation level, silent null-skipping, and an assumed MoM formula: now a deterministic single-ward single-category calculator that refuses cross-segment requests, prints a full null audit with reason flags (NULL_SPEND / PRIOR_SPEND_NULL / NO_PRIOR_PERIOD), shows the substituted formula per row, and refuses unspecified --growth-type.

**UC-X — Ask My Documents** ([165eaaa](https://github.com/nasscomAI/prompt-to-production/pull/1978/commits/165eaaab5af02c874bc88370f284256a254afca1), [b38284a](https://github.com/nasscomAI/prompt-to-production/pull/1978/commits/b38284a57a13df516d5b1a2081ffa8eb34d93291))
Built a deterministic single-source policy Q&A over three documents answering only with verbatim quotes cited by filename+section, refusing cross-document ambiguity and uncovered questions with the exact refusal template, banning hedging. Follow-up fixed retrieval misfires: tie-based document dropping, keyword hijacks, wfh vocabulary mismatch, and bare entitlement questions.