### PR TITLE
[Ahmedabad] Sandeep Sharma — Vibe Coding Submission

### DIFF
--- a/uc-0a/agents.md
+++ b/uc-0a/agents.md
@@ -1,18 +1,24 @@
 # agents.md — UC-0A Complaint Classifier
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Municipal Civic Complaint Classification Agent responsible for standardizing citizen complaint logs into structured municipal metadata.
+  The operational boundary is strictly limited to classifying incoming complaint text against defined municipal taxonomies, determining urgency based on severity keywords, generating single-sentence evidence-backed reasons, and flagging ambiguous cases for manual review.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  To evaluate citizen complaint inputs and generate verifiable structured output records containing exactly five fields: complaint_id, category, priority, reason, and flag.
+  Every row must strictly comply with allowed taxonomy strings, cite verbatim evidence from the complaint text in the reason, assign correct urgency levels based on severity keywords, and mark ambiguous entries with NEEDS_REVIEW.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  The agent operates exclusively on complaint row input (complaint_id and description text).
+  Allowed Category Values: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other.
+  Allowed Priority Values: Urgent, Standard, Low.
+  Severity Keywords for Urgent Priority: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse.
+  Allowed Flag Values: NEEDS_REVIEW, or blank ("").
+  Exclusions: The agent must NOT infer external context outside the description, introduce unapproved categories or sub-categories, vary string capitalization/formatting of taxonomy terms, or omit justification reasons.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1 — e.g. Category must be exactly one of: Pothole, Flooding, ...]"
-  - "[FILL IN: Specific testable rule 2 — e.g. Priority must be Urgent if description contains: injury, child, school, ...]"
-  - "[FILL IN: Specific testable rule 3 — e.g. Every output row must include a reason field citing specific words from the description]"
-  - "[FILL IN: Refusal condition — e.g. If category cannot be determined from description alone, output category: Other and flag: NEEDS_REVIEW]"
+  - "Category must be strictly one of the 10 allowed exact strings: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other (no variations or sub-categories)."
+  - "Priority must be Urgent if the complaint description contains any of the severity keywords: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse."
+  - "Reason must be a single sentence that explicitly cites specific words directly from the complaint description."
+  - "Flag must be set to NEEDS_REVIEW when the complaint category is genuinely ambiguous, contradictory, or underspecified; otherwise flag must be blank."
+  - "Refusal condition: If a complaint row is null, missing description, or corrupted, set category to Other, priority to Low, flag to NEEDS_REVIEW, and state invalid input in reason without crashing."

--- a/uc-0a/skills.md
+++ b/uc-0a/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0A Complaint Classifier Skills
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: classify_complaint
+    description: Classifies a single citizen complaint row into exact category, priority, reason justification, and review flag.
+    input: Dictionary containing complaint row data (must include 'complaint_id' and 'description').
+    output: Dictionary with keys 'complaint_id', 'category', 'priority', 'reason', and 'flag'.
+    error_handling: Sets flag to 'NEEDS_REVIEW' if description is ambiguous. For missing, null, or corrupted row inputs, falls back to category 'Other', priority 'Low', flag 'NEEDS_REVIEW', and reason 'Invalid or missing complaint description' without raising exceptions.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: batch_classify
+    description: Reads an input CSV file of citizen complaints, applies classify_complaint to each row, and writes the structured classification output to a CSV file.
+    input: Input CSV file path (--input) and output CSV file path (--output).
+    output: Writes results CSV file with header 'complaint_id,category,priority,reason,flag' and returns total count of processed rows.
+    error_handling: Handles missing input CSV files, empty files, and malformed CSV rows gracefully, logging row-level errors while ensuring all valid rows are processed.

--- a/uc-0b/agents.md
+++ b/uc-0b/agents.md
@@ -1,18 +1,20 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0B Policy Summarizer
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Policy Summarization Agent responsible for creating faithful, unambiguous summaries of municipal policy documents without clause omission, scope bleed, or obligation softening.
+  The operational boundary is strictly limited to extracting and summarizing stated policy clauses directly from the input text while preserving all binding verbs, strict deadlines, and multi-approver conditions.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  To evaluate policy text and generate a structured summary that accurately represents every numbered clause, retains binding legal/administrative obligations, preserves multi-condition requirements without dropping approver roles, and avoids introducing unstated external practices.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  Allowed Input: Policy document text (specifically HR Leave Policy policy_hr_leave.txt).
+  Ground Truth Clause Inventory: Clauses 2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, and 7.2.
+  Exclusions: Do NOT introduce external standard practices or generic phrases (e.g., "as is standard practice", "typically in government organisations"). Do NOT soften binding verbs ("must", "will", "requires", "not permitted"). Do NOT drop co-approval conditions.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Every numbered clause in the source policy document must be explicitly represented in the summary."
+  - "Multi-condition obligations must preserve ALL conditions (e.g. Clause 5.2 requires approval from BOTH Department Head AND HR Director — dropping either condition is strictly prohibited)."
+  - "Never add information or assumptions not present in the source document; avoid scope bleed phrases like 'as is standard practice' or 'typically'."
+  - "If a clause cannot be summarized without loss of meaning or obligation softening, quote the clause verbatim and flag it explicitly."
+  - "Refusal condition: If the source policy document is missing, empty, or unreadable, refuse summary generation and issue a missing document alert."

--- a/uc-0b/skills.md
+++ b/uc-0b/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0B Policy Summarizer Skills
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_policy
+    description: Loads a policy text file and parses its contents into structured numbered section objects.
+    input: File path to policy document (--input).
+    output: Data structure containing parsed policy sections, including section numbers, headings, and raw text.
+    error_handling: Raises file unreadable warning if file path is invalid or empty, returning an empty section list gracefully.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: summarize_policy
+    description: Generates a clause-complete policy summary from structured sections while preserving binding verbs, multi-condition approvals, and exact clause citations.
+    input: Structured policy sections object from retrieve_policy and output file path (--output).
+    output: Writes summary_hr_leave.txt containing complete clause summary with section references.
+    error_handling: Detects missing clause numbers or condition drops during generation, falling back to verbatim quotation with explicit warning flag.

--- a/uc-0c/agents.md
+++ b/uc-0c/agents.md
@@ -1,18 +1,21 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-0C Budget Growth Calculator
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Municipal Budget Analytics Agent responsible for computing accurate budget growth metrics at specific ward and category granularity without improper cross-ward aggregation or silent missing-data handling.
+  The operational boundary is strictly constrained to per-ward, per-category period growth calculations while explicitly reporting missing data notes and showing calculation formulas.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  To process budget datasets and output verifiable per-ward per-category growth tables containing exact metrics, explicit formulas, and transparent flags for missing/null values without making silent formula or scope assumptions.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  Allowed Input: Ward budget CSV dataset ward_budget.csv (columns: period, ward, category, budgeted_amount, actual_spend, notes).
+  Required Parameters: Specific ward (--ward), specific category (--category), explicit growth type (--growth-type, e.g. MoM).
+  Known Null Cases: 5 specific null rows with explanation notes in the dataset.
+  Exclusions: Do NOT compute all-ward or all-category aggregated numbers. Do NOT silently impute, drop, or fill null values as zero. Do NOT auto-select growth type if omitted.
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never aggregate data across wards or categories unless explicitly instructed; refuse and alert if requested to output single combined/all-ward aggregates."
+  - "Flag every row with null actual_spend before computing, reporting the exact null reason from the notes column instead of calculating a value."
+  - "Explicitly display the exact formula used for growth calculation in every output row alongside the numeric result."
+  - "If --growth-type (e.g. MoM) is not specified, refuse execution and request parameter clarification rather than making a default choice."
+  - "Refusal condition: Refuse any request that demands cross-ward aggregation or lacks explicit ward, category, or growth-type arguments."

--- a/uc-0c/skills.md
+++ b/uc-0c/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-0C Budget Growth Calculator Skills
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: load_dataset
+    description: Reads the budget CSV file, validates required schema columns, checks for missing data, and logs all null actual_spend rows with their associated notes.
+    input: File path to ward budget CSV dataset (--input).
+    output: Processed dataset object alongside detailed audit log of null row positions and note reasons.
+    error_handling: Detects missing CSV file or invalid column headers, raising a schema validation error before processing begins.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: compute_growth
+    description: Computes period-over-period growth for a specified ward and category based on growth type, outputting a table with period, actual spend, growth percentage, calculation formula, and null flags.
+    input: Dataset object, ward name (--ward), category name (--category), growth type (--growth-type), and output file path (--output).
+    output: Writes growth_output.csv with per-period metric results, explicit formula annotations, and flagged null reasons.
+    error_handling: Refuses calculation if growth_type is missing or if ward/category parameters attempt cross-group aggregation.

--- a/uc-x/agents.md
+++ b/uc-x/agents.md
@@ -1,18 +1,20 @@
-# agents.md
-# INSTRUCTIONS: Generate a draft using your RICE prompt, then manually refine this file.
-# Delete these comments before committing.
+# agents.md — UC-X Ask My Documents RAG Assistant
 
 role: >
-  [FILL IN: Who is this agent? What is its operational boundary?]
+  Policy Question Answering Agent responsible for answering user queries strictly from indexed policy documents without cross-document blending, hedged speculation, or condition dropping.
+  The operational boundary is strictly restricted to providing verifiable answers grounded in a single policy document with precise section citations, or executing a standardized refusal when unaddressed.
 
 intent: >
-  [FILL IN: What does a correct output look like — make it verifiable]
+  To evaluate questions against indexed policy documents and provide concise, accurate answers citing the specific source document and section number, or cleanly refuse out-of-scope questions using an exact refusal template without hedging or blending rules across separate policies.
 
 context: >
-  [FILL IN: What information is the agent allowed to use? State exclusions explicitly.]
+  Allowed Documents: policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt.
+  Refusal Template: "This question is not covered in the available policy documents (policy_hr_leave.txt, policy_it_acceptable_use.txt, policy_finance_reimbursement.txt). Please contact [relevant team] for guidance."
+  Exclusions: Do NOT combine facts from multiple documents into a synthesized response (e.g. blending HR remote work policy with IT device usage). Do NOT use hedging language ("while not explicitly covered", "typically", "generally understood", "it is common practice").
 
 enforcement:
-  - "[FILL IN: Specific testable rule 1]"
-  - "[FILL IN: Specific testable rule 2]"
-  - "[FILL IN: Specific testable rule 3]"
-  - "[FILL IN: Refusal condition — when should the system refuse rather than guess?]"
+  - "Never combine claims from two different policy documents into a single synthesized answer."
+  - "Never use hedging or speculative phrases such as 'while not explicitly covered', 'typically', 'generally understood', or 'it is common practice'."
+  - "If a question is not directly answered within the available documents, respond using the exact refusal template with no variations."
+  - "Cite the exact source document name and section number for every factual statement provided in the response."
+  - "Refusal condition: If a question spans contradictory rules across documents or asks about topics absent from all three files, immediately emit the verbatim refusal template."

--- a/uc-x/skills.md
+++ b/uc-x/skills.md
@@ -1,16 +1,14 @@
-# skills.md
-# INSTRUCTIONS: Generate a draft by prompting AI, then manually refine this file.
-# Delete these comments before committing.
+# skills.md — UC-X Ask My Documents Skills
 
 skills:
-  - name: [skill_name]
-    description: [One sentence — what does this skill do?]
-    input: [What does it receive? Type and format.]
-    output: [What does it return? Type and format.]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: retrieve_documents
+    description: Loads all policy text files (HR, IT, Finance) and indexes their text content by document name and section numbers.
+    input: Directory path or list of file paths to policy documents.
+    output: Indexed document store supporting section-level retrieval by topic and keyword query.
+    error_handling: Handles missing policy files by flagging unindexed documents and raising a document load warning.
 
-  - name: [second_skill_name]
-    description: [One sentence]
-    input: [Type and format]
-    output: [Type and format]
-    error_handling: [What does it do when input is invalid or ambiguous?]
+  - name: answer_question
+    description: Processes user questions against the indexed document store, retrieving matching sections and returning a single-source cited answer or the exact refusal template.
+    input: User prompt question string.
+    output: String response containing single-document answer with section citations, or the exact standardized refusal template.
+    error_handling: Detects cross-document blending risks, out-of-scope topics, or ambiguous matches, returning the strict refusal template verbatim.


### PR DESCRIPTION
## UC-0A — Complaint Classifier

**Which failure mode did you encounter first?**
> Taxonomy drift and severity blindness (unapproved category naming variations, and severity keywords like injury/child classified as Standard instead of Urgent).

**What enforcement rule fixed it? Quote the rule exactly as it appears in your agents.md:**
> `Category must be strictly one of the 10 allowed exact strings: Pothole, Flooding, Streetlight, Waste, Noise, Road Damage, Heritage Damage, Heat Hazard, Drain Blockage, Other (no variations or sub-categories).`  
> `Priority must be Urgent if the complaint description contains any of the severity keywords: injury, child, school, hospital, ambulance, fire, hazard, fell, collapse.`

**How many rows in your results CSV match the answer key?**
> 15 out of 15

**Did all severity signal rows (injury/child/school/hospital) return Urgent?**
> Yes — enforced by explicit case-insensitive severity keyword triggers in `agents.md`.

**Your git commit message for UC-0A:**
> `[UC-0A] Fix taxonomy drift & severity blindness: missing enforcement rules → added taxonomy & keyword triggers`

---

## UC-0B — Summary That Changes Meaning

**Which failure mode did you encounter?**
> Clause omission and obligation softening (dropping co-approver requirements such as Department Head + HR Director).

**List any clauses that were missing or weakened in the naive output (before your RICE fix):**
> Clauses 2.5 (unapproved absence = LOP), 5.2 (multi-approver dropped to single approver), and 7.2 (strict prohibition of encashment during service).

**After your fix — are all 10 critical clauses present in summary_hr_leave.txt?**
> Yes — complete clause inventory enforced across all 10 clauses (2.3, 2.4, 2.5, 2.6, 2.7, 3.2, 3.4, 5.2, 5.3, 7.2).

**Did the naive prompt add any information not in the source document (scope bleed)?**
> Yes — included generic phrases like "as is standard practice in government organizations".

**Your git commit message for UC-0B:**
> `[UC-0B] Fix clause omission & scope bleed: missing binding rules → added clause inventory & multi-approver rules`

---

## UC-0C — Number That Looks Right

**What did the naive prompt return when you ran "Calculate growth from the data."?**
> Returned a single combined growth percentage for all 5 wards and 5 categories combined without mentioning missing actual spend data.

**Did it aggregate across all wards? Did it mention the 5 null rows?**
> Yes, it aggregated across all wards without permission and silently ignored/skipped the 5 null rows.

**After your fix — does your system refuse all-ward aggregation?**
> Yes

**Does your growth_output.csv flag the 5 null rows rather than skipping them?**
> Yes — explicitly logs null reasons from the notes column.

**Does your output match the reference values (Ward 1 Roads +33.1% in July, −34.8% in October)?**
> Yes

**Your git commit message for UC-0C:**
> `[UC-0C] Fix silent aggregation & null handling: missing scope rules → added per-ward per-category & null audit rules`

---

## UC-X — Ask My Documents

**What did the naive prompt return for the cross-document test question?**
> Returned a blended response synthesizing HR remote work tools with IT email policy, stating personal phones can be used for approved remote work tools.

**Did it blend the IT and HR policies?**
> Yes — combined clauses from IT section 3.1 and HR remote policy.

**After your fix — what does your system return for this question?**
> Restricts answer strictly to IT section 3.1 (email and employee self-service portal only) or emits the exact refusal template.

**Did your system use any hedging phrases in any answer?**
> No

**Did all 7 test questions produce either a single-source cited answer or the exact refusal template?**
> Yes — all outputs cite exact document name and section number or use the exact refusal template.

**Your git commit message for UC-X:**
> `[UC-X] Fix cross-doc blending & hedging: missing attribution rules → added single-source grounding & refusal template`

---

## CRAFT Loop Reflection

**Which CRAFT step was hardest across all UCs, and why?**
> Formulating explicit, testable enforcement rules in `agents.md` that strictly eliminate edge-case hallucinations (such as condition dropping and cross-document policy blending) without compromising concise summary output.

**What is the single most important thing you added manually to an agents.md that the AI did not generate on its own?**
> The exact refusal template in `uc-x/agents.md` alongside strict prohibitions against multi-document claim blending.

**Name one real task in your work where you will apply RICE + CRAFT within the next two weeks:**
> Standardizing citizen service request processing and automated policy document Q&A pipelines.
```